### PR TITLE
binutils: fix assert op check

### DIFF
--- a/bfd/elfnn-loongarch.c
+++ b/bfd/elfnn-loongarch.c
@@ -1467,7 +1467,7 @@ perform_relocation (const Elf_Internal_Rela *rel, bfd_vma value,
 
     case R_LARCH_SOP_ASSERT:
       r = loongarch_pop (&opr1);
-      if (r != bfd_reloc_ok && opr1 == false)
+      if (r != bfd_reloc_ok || opr1 == false)
         r = bfd_reloc_notsupported;
       break;
 


### PR DESCRIPTION
When building with gcc 10.2.1, the build fails with:

```
elfnn-loongarch.c: In function ‘loongarch_elf_relocate_section’:
elfnn-loongarch.c:1470:29: error: ‘opr1’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
elfnn-loongarch.c:1445:11: note: ‘opr1’ was declared here
cc1: all warnings being treated as errors
```

The commit fixes the incorrect logic to become: `loongarch_pop` does not succeed or the assertion check failed.