### PR TITLE
opcodes: change code format by patch rv

### DIFF
--- a/bfd/cpu-loongarch.c
+++ b/bfd/cpu-loongarch.c
@@ -22,7 +22,7 @@
 #include "bfd.h"
 #include "libbfd.h"
 
-static const bfd_arch_info_type bfd_loongarch32_arch = 
+static const bfd_arch_info_type bfd_loongarch32_arch =
 {
   32,                     /* 32 bits in a word.  */
   32,                     /* 64 bits in an address.  */
@@ -40,7 +40,7 @@ static const bfd_arch_info_type bfd_loongarch32_arch =
   0,
 };
 
-const bfd_arch_info_type bfd_loongarch_arch = 
+const bfd_arch_info_type bfd_loongarch_arch =
 {
   32,                   /* 32 bits in a word.  */
   64,                   /* 64 bits in an address.  */

--- a/bfd/elfnn-loongarch.c
+++ b/bfd/elfnn-loongarch.c
@@ -60,7 +60,7 @@ struct _bfd_loongarch_elf_obj_tdata
 {
   struct elf_obj_tdata root;
 
-  /* tls_type for each local got entry.  */
+  /* The tls_type for each local got entry.  */
   char *local_got_tls_type;
 };
 
@@ -295,7 +295,7 @@ elfNN_loongarch_get_local_sym_hash (struct loongarch_elf_link_hash_table *htab,
       ret->elf.got.refcount = -1;
       ret->elf.def_dynamic = 0;
       ret->elf.def_regular = 1;
-      ret->elf.ref_dynamic = 0; /* this should be always 0 for local  */
+      ret->elf.ref_dynamic = 0; /* This should be always 0 for local.  */
       ret->elf.ref_regular = 0;
       ret->elf.forced_local = 1;
       ret->elf.root.type = bfd_link_hash_defined;
@@ -531,7 +531,7 @@ loongarch_elf_record_tls_and_got_reference (bfd *abfd,
     case GOT_NORMAL:
     case GOT_TLS_GD:
     case GOT_TLS_IE:
-      /* need GOT */
+      /* Need GOT. */
       if (htab->elf.sgot == NULL &&
           !loongarch_elf_create_got_section (htab->elf.dynobj, info))
         return false;
@@ -545,7 +545,7 @@ loongarch_elf_record_tls_and_got_reference (bfd *abfd,
         elf_local_got_refcounts (abfd)[symndx]++;
       break;
     case GOT_TLS_LE:
-      /* no need for GOT */
+      /* No need for GOT. */
       break;
     default:
       _bfd_error_handler (_ ("Interl error: unreachable."));
@@ -671,7 +671,7 @@ loongarch_elf_check_relocs (bfd *abfd, struct bfd_link_info *info,
 
         case R_LARCH_SOP_PUSH_TLS_GOT:
           if (bfd_link_pic (info))
-            /* may fail for lazy-bind */
+            /* May fail for lazy-bind. */
             info->flags |= DF_STATIC_TLS;
 
           if (!loongarch_elf_record_tls_and_got_reference (
@@ -1904,9 +1904,9 @@ loongarch_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
           RELOC_FOR_GLOBAL_SYMBOL (
             info, input_bfd, input_section, rel, r_symndx, symtab_hdr,
             sym_hashes, h, sec, relocation, unresolved_reloc, warned, ignored);
-          /* here means symbol isn't local symbol only and 'h != NULL' */
+          /* Here means symbol isn't local symbol only and 'h != NULL'. */
 
-          /* 'unresolved_syms_in_objects' specify how to deal with undefined
+          /* The 'unresolved_syms_in_objects' specify how to deal with undefined
 	     symbol. And 'dynamic_undefined_weak' specify what to do when
 	     meeting undefweak.  */
 
@@ -1955,7 +1955,7 @@ loongarch_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
       if (bfd_link_relocatable (info))
         continue;
 
-      /* r_symndx will be STN_UNDEF (zero) only for relocs against symbols
+      /* The r_symndx will be STN_UNDEF (zero) only for relocs against symbols
 	 from removed linkonce sections, or sections discarded by a linker
 	 script. Also for R_*_SOP_PUSH_ABSOLUTE and PCREL to specify const.  */
       if (r_symndx == STN_UNDEF || bfd_is_abs_section (sec))
@@ -2309,7 +2309,7 @@ loongarch_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
 
                       outrel.r_offset = sec_addr (got) + off;
                       outrel.r_info = ELFNN_R_INFO (0, R_LARCH_RELATIVE);
-                      outrel.r_addend = relocation; /* link-time addr */
+                      outrel.r_addend = relocation; /* Link-time addr. */
                       loongarch_elf_append_rela (output_bfd, s, &outrel);
                     }
 
@@ -2552,7 +2552,7 @@ loongarch_elf_finish_dynamic_symbol (bfd *output_bfd,
 
       plt_idx = (h->plt.offset - PLT_HEADER_SIZE) / PLT_ENTRY_SIZE;
 
-      /* one of '.plt' and '.iplt' represents */
+      /* One of '.plt' and '.iplt' represents. */
       BFD_ASSERT (!!htab->elf.splt ^ !!htab->elf.iplt);
 
       if (htab->elf.splt)
@@ -2666,7 +2666,7 @@ loongarch_elf_finish_dynamic_symbol (bfd *output_bfd,
         }
       else if (bfd_link_pic (info) && SYMBOL_REFERENCES_LOCAL (info, h))
         {
-          BFD_ASSERT (h->got.offset & 1 /* has been filled in addr */);
+          BFD_ASSERT (h->got.offset & 1 /* Has been filled in addr. */);
           asection *sec = h->root.u.def.section;
           rela.r_info = ELFNN_R_INFO (0, R_LARCH_RELATIVE);
           rela.r_addend = h->root.u.def.value + sec->output_section->vma +
@@ -2979,7 +2979,7 @@ loongarch_elf_grok_prstatus (bfd *abfd, Elf_Internal_Note *note)
       return false;
 
     case sizeof (
-      prstatus_t): /* sizeof(struct elf_prstatus) on Linux/Loongarch.  */
+      prstatus_t): /* The sizeof(struct elf_prstatus) on Linux/Loongarch.  */
       /* pr_cursig */
       elf_tdata (abfd)->core->signal =
         bfd_get_16 (abfd, note->descdata + offsetof (prstatus_t, pr_cursig));
@@ -3098,7 +3098,7 @@ _loongarch_bfd_set_section_contents (bfd *abfd, sec_ptr section,
 #define bfd_elfNN_bfd_link_hash_table_create                                  \
   loongarch_elf_link_hash_table_create
 #define bfd_elfNN_bfd_reloc_name_lookup loongarch_reloc_name_lookup
-#define elf_info_to_howto_rel NULL /* fall through to elf_info_to_howto */
+#define elf_info_to_howto_rel NULL /* Fall through to elf_info_to_howto. */
 #define elf_info_to_howto loongarch_info_to_howto_rela
 #define bfd_elfNN_bfd_merge_private_bfd_data                                  \
   elfNN_loongarch_merge_private_bfd_data

--- a/bfd/elfxx-loongarch.c
+++ b/bfd/elfxx-loongarch.c
@@ -28,7 +28,7 @@
 /* This does not include any relocation information, but should be
    good enough for GDB or objdump to read the file.  */
 
-static reloc_howto_type howto_table[] = 
+static reloc_howto_type howto_table[] =
 {
 #define LOONGARCH_HOWTO(r_name)                                               \
   HOWTO (R_LARCH_##r_name, 0, 3, 32, false, 0, complain_overflow_signed,      \
@@ -104,7 +104,7 @@ struct elf_reloc_map
   enum elf_loongarch_reloc_type elf_val;
 };
 
-static const struct elf_reloc_map loong_reloc_map[] = 
+static const struct elf_reloc_map loong_reloc_map[] =
 {
   { BFD_RELOC_NONE, R_LARCH_NONE },
   { BFD_RELOC_32, R_LARCH_32 },

--- a/gas/NEWS
+++ b/gas/NEWS
@@ -2,6 +2,10 @@
 
 Changes in 2.37:
 
+* Add support for the LoongArch instruction set.
+
+Changes in 2.37:
+
 * arm-symbianelf support removed.
 
 * Add support for Realm Management Extension (RME) for AArch64.

--- a/gas/config/loongarch-parse.y
+++ b/gas/config/loongarch-parse.y
@@ -241,7 +241,7 @@ emit_bin (int op)
 	  opr1 = opr1 << opr2;
 	  break;
 	case RIGHT_OP:
-	  /* Algorithm right shift  */
+	  /* Algorithm right shift.  */
 	  opr1 = (offsetT)opr1 >> (offsetT)opr2;
 	  break;
 	case '<':

--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -338,7 +338,7 @@ s_dtprel (int bytes)
   demand_empty_rest_of_line ();
 }
 
-static const pseudo_typeS loongarch_pseudo_table[] = 
+static const pseudo_typeS loongarch_pseudo_table[] =
 {
   { "align", s_loongarch_align, -4 },
   { "dword", cons, 8 },
@@ -390,13 +390,13 @@ setup_internal_label_here (unsigned long label)
   colon (loongarch_internal_label_name (label, 0));
 }
 
-extern void /* no static. used by 'loongarch-parse.y' */
+extern void /* No static. used by 'loongarch-parse.y'. */
 get_internal_label (expressionS *label_expr, unsigned long label,
-                    int augend /* 0 for previous, 1 for next */);
+                    int augend /* 0 for previous, 1 for next. */);
 
 void
 get_internal_label (expressionS *label_expr, unsigned long label,
-                    int augend /* 0 for previous, 1 for next */)
+                    int augend /* 0 for previous, 1 for next. */)
 {
   assert (label < INTERNAL_LABEL_SPECIAL);
   if (augend == 0 && internal_label_count[label] == 0)
@@ -473,7 +473,7 @@ loongarch_args_parser_can_match_arg_helper (char esc_ch1, char esc_ch2,
           bfd_reloc_code_real_type reloc_type = BFD_RELOC_NONE;
           reloc_num_we_have -= reloc_num;
           if (reloc_num_we_have == 0)
-            as_fatal (_ ("expr too huge") /* want one more reloc */);
+            as_fatal (_ ("expr too huge") /* Want one more reloc. */);
           if (esc_ch1 == 'u')
             {
               if (strncmp (bit_field, "10:12", strlen ("10:12")) == 0)
@@ -553,7 +553,7 @@ loongarch_args_parser_can_match_arg_helper (char esc_ch1, char esc_ch2,
 
   do
     {
-      /* check imm overflow */
+      /* Check imm overflow. */
       int bit_width, bits_needed_s, bits_needed_u;
       char *t;
 
@@ -566,7 +566,7 @@ loongarch_args_parser_can_match_arg_helper (char esc_ch1, char esc_ch2,
       bit_width = loongarch_get_bit_field_width (bit_field, &t);
 
       if (bit_width == -1)
-        /* no specify bit width */
+        /* No specify bit width. */
         break;
 
       imm = ret;
@@ -586,7 +586,7 @@ loongarch_args_parser_can_match_arg_helper (char esc_ch1, char esc_ch2,
 
       if ((esc_ch1 == 's' && bit_width < bits_needed_s) ||
           (esc_ch1 != 's' && bit_width < bits_needed_u))
-        /* how to do after we detect overflow */
+        /* How to do after we detect overflow. */
         as_fatal (_ ("Immediate overflow.\n"
                      "format: %c%c%s\n"
                      "arg: %s"),
@@ -660,7 +660,7 @@ check_this_insn_before_appending (struct loongarch_cl_insn *ip)
             (ip->insn_bin & 0xffff0000) == 0x38700000 ||
             (ip->insn_bin & 0xffff0000) == 0x38710000))
     {
-      /* for AMO insn amswap.[wd], amadd.[wd], etc. */
+      /* For AMO insn amswap.[wd], amadd.[wd], etc. */
       if (ip->args[0] != 0 &&
           (ip->args[0] == ip->args[1] || ip->args[0] == ip->args[2]))
         as_fatal (
@@ -671,7 +671,7 @@ check_this_insn_before_appending (struct loongarch_cl_insn *ip)
            (ip->insn->mask == 0xffc00000 &&
             (ip->insn_bin & 0xff800000) == 0x00800000))
     {
-      /* for bstr(ins|pick).[wd] */
+      /* For bstr(ins|pick).[wd] */
       if (ip->args[2] < ip->args[3])
         as_fatal (_ ("bstr(ins|pick).[wd] require msbd >= lsbd"));
     }
@@ -739,7 +739,7 @@ append_fixp_and_insn (struct loongarch_cl_insn *ip)
   dwarf2_emit_insn (0);
 }
 
-/* ask helper for returning a malloced c_str or NULL */
+/* Ask helper for returning a malloced c_str or NULL. */
 static char *
 assember_macro_helper (const char *const args[], void *context_ptr)
 {
@@ -823,8 +823,8 @@ assember_macro_helper (const char *const args[], void *context_ptr)
   return ret;
 }
 
-/* accept instructions separated by ';'
-* assuming 'not starting with space and not ending with space' or pass in empty c_str */
+/* Accept instructions separated by ';'
+* assuming 'not starting with space and not ending with space' or pass in empty c_str. */
 static void
 loongarch_assemble_INSNs (char *str)
 {

--- a/gas/config/tc-loongarch.h
+++ b/gas/config/tc-loongarch.h
@@ -27,7 +27,7 @@
 #define WORKING_DOT_WORD 1
 #define REPEAT_CONS_EXPRESSIONS
 
-/* early than md_begin */
+/* Early than md_begin. */
 #define md_after_parse_args loongarch_after_parse_args
 extern void loongarch_after_parse_args (void);
 
@@ -68,8 +68,8 @@ extern void loongarch_cfi_frame_initial_instructions (void);
 #define tc_parse_to_dw2regnum tc_loongarch_parse_to_dw2regnum
 extern void tc_loongarch_parse_to_dw2regnum (expressionS *);
 
-/* a enumerated values to specific how to deal with align in '.text' */
-/* now we want to fill 'andi $r0,$r0,0x0' */
+/* A enumerated values to specific how to deal with align in '.text'. */
+/* Now we want to fill 'andi $r0,$r0,0x0'. */
 #define loongarch_nop_opcode() 0
 #define NOP_OPCODE (loongarch_nop_opcode ())
 

--- a/gas/doc/as.texi
+++ b/gas/doc/as.texi
@@ -538,6 +538,11 @@ gcc(1), ld(1), and the Info entries for @file{binutils} and @file{ld}.
    [@b{-mabi}=@var{ABI}]
    [@b{-mlittle-endian}|@b{-mbig-endian}]
 @end ifset
+@ifset LOONGARCH
+
+@emph{Target LOONGARCH options:}
+   [@b{-fpic}|@b{-fPIC}|@b{-fno-pic}]
+@end ifset
 @ifset RL78
 
 @emph{Target RL78 options:}
@@ -1833,6 +1838,25 @@ RISC-V processor.
 @c man end
 @c man begin INCLUDE
 @include c-riscv.texi
+@c ended inside the included file
+@end ifset
+
+@end ifset
+
+@ifset LOONGARCH
+
+@ifclear man
+@xref{LoongArch-Options}, for the options available when @value{AS} is configured
+for a LoongArch processor.
+@end ifclear
+
+@ifset man
+@c man begin OPTIONS
+The following options are available when @value{AS} is configured for a
+LoongArch processor.
+@c man end
+@c man begin INCLUDE
+@include c-loongarch.texi
 @c ended inside the included file
 @end ifset
 
@@ -7897,6 +7921,9 @@ subject, see the hardware manufacturer's manual.
 @ifset RISCV
 * RISC-V-Dependent::            RISC-V Dependent Features
 @end ifset
+@ifset LOONGARCH
+* LoongArch-Dependent::         LoongArch Dependent Features
+@end ifset
 @ifset RL78
 * RL78-Dependent::              RL78 Dependent Features
 @end ifset
@@ -8135,6 +8162,10 @@ family.
 
 @ifset RISCV
 @include c-riscv.texi
+@end ifset
+
+@ifset LOONGARCH
+@include c-loongarch.texi
 @end ifset
 
 @ifset RL78

--- a/gas/doc/c-loongarch.texi
+++ b/gas/doc/c-loongarch.texi
@@ -1,0 +1,39 @@
+@c Copyright (C) 2021-2021 Free Software Foundation, Inc.
+@c This is part of the GAS anual.
+@c For copying conditions, see the file as.texinfo
+@c man end
+
+@ifset GENERIC
+@page
+@node LoongArch-Dependent
+@chapter LoongArch Dependent Features
+@end ifset
+@ifclear GENERIC
+@node Machine Dependencies
+@chapter LoongArch Dependent Features
+@end ifclear
+
+@cindex LoongArch support
+@menu
+* LoongArch-Options::        LoongArch Options
+@end menu
+
+@node LoongArch-Options
+@section LoongArch Options
+
+The following table lists all available LoongArch specific options.
+
+@c man begin OPTIONS
+@table @gcctabopt
+
+@cindex @samp{-fpic} option, LoongArch
+@item -fpic
+@itemx -fPIC
+Generate position-independent code
+
+@cindex @samp{-fno-pic} option, LoongArch
+@item -fno-pic
+Don't generate position-independent code (default)
+
+@end table
+@c man end

--- a/gas/testsuite/gas/loongarch/loongarch.exp
+++ b/gas/testsuite/gas/loongarch/loongarch.exp
@@ -1,0 +1,23 @@
+# Expect script for LoongArch assembler tests.
+#   Copyright (C) 2021-2021 Free Software Foundation, Inc.
+#
+# This file is part of the GNU Binutils.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
+# MA 02110-1301, USA.
+
+if [istarget loongarch*-*-*] {
+    run_dump_tests [lsort [glob -nocomplain $srcdir/$subdir/*.d]]
+}

--- a/gas/testsuite/gas/loongarch/nop.d
+++ b/gas/testsuite/gas/loongarch/nop.d
@@ -1,0 +1,10 @@
+#as:
+#objdump: -dr
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+03400000[ 	]+andi .*

--- a/gas/testsuite/gas/loongarch/nop.s
+++ b/gas/testsuite/gas/loongarch/nop.s
@@ -1,0 +1,2 @@
+target:
+	nop

--- a/gdb/arch/loongarch-linux-nat.c
+++ b/gdb/arch/loongarch-linux-nat.c
@@ -15,7 +15,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/* for external ptrace */
+/* For external ptrace. */
 #ifdef GDBSERVER
 #include "server.h"
 #include "nat/gdb_ptrace.h"

--- a/gdb/loongarch-linux-nat.c
+++ b/gdb/loongarch-linux-nat.c
@@ -478,7 +478,8 @@ static int watch_readback_valid;
 
 /* Cached watch register read values.  */
 
-static struct pt_watch_regs watch_readback = {
+static struct pt_watch_regs watch_readback =
+{
   .max_valid = MAX_DEBUG_REGISTER,
 };
 
@@ -487,7 +488,8 @@ static struct loongarch_watchpoint *current_watches;
 /*  The current set of watch register values for writing the
     registers.  */
 
-static struct pt_watch_regs watch_mirror = {
+static struct pt_watch_regs watch_mirror =
+{
   .max_valid = MAX_DEBUG_REGISTER,
 };
 
@@ -698,7 +700,8 @@ loongarch_linux_nat_target::insert_watchpoint (CORE_ADDR addr, int len,
                                                enum target_hw_bp_type type,
                                                struct expression *cond)
 {
-  struct pt_watch_regs regs = {
+  struct pt_watch_regs regs =
+  {
     .max_valid = MAX_DEBUG_REGISTER,
   };
   struct loongarch_watchpoint *new_watch;

--- a/gdb/loongarch-linux-tdep.c
+++ b/gdb/loongarch-linux-tdep.c
@@ -54,7 +54,7 @@ loongarch_supply_elf_gregset (const struct regset *r,
 
   if (regno == -1)
     {
-      /* $r0 = zero */
+      /* Set $r0 = 0. */
       regcache->raw_supply_zeroed (regs->r);
 
       for (int i = 1; i < 32; i++)
@@ -63,11 +63,11 @@ loongarch_supply_elf_gregset (const struct regset *r,
         regcache->raw_supply (regs->r + i, (const void *)buf);
         }
 
-      /* base(pc) = regsize * regs->pc */
+      /* Size base(pc) = regsize * regs->pc. */
       buf = (const gdb_byte*)gprs + regsize * regs->pc;
       regcache->raw_supply (regs->pc, (const void *)buf);
 
-      /* base(badvaddr) = regsize * regs->badvaddr */
+      /* Size base(badvaddr) = regsize * regs->badvaddr. */
       buf = (const gdb_byte*)gprs + regsize * regs->badvaddr;
       regcache->raw_supply (regs->badvaddr, (const void *)buf);
     }
@@ -77,7 +77,7 @@ loongarch_supply_elf_gregset (const struct regset *r,
           || (regs->pc == regno)
           || (regs->badvaddr == regno))
     {
-    /* offset(regno) = regsize * (regno - regs->r) */
+    /* Offset offset(regno) = regsize * (regno - regs->r). */
     buf = (const gdb_byte*)gprs + regsize * (regno - regs->r);
     regcache->raw_supply (regno, (const void *)buf);
     }
@@ -101,11 +101,11 @@ loongarch_fill_elf_gregset (const struct regset *r,
         regcache->raw_collect (regs->r + i, (void *)buf);
         }
 
-      /* base(pc) = regsize * regs->pc */
+      /* Size base(pc) = regsize * regs->pc. */
       buf = (gdb_byte *)gprs + regsize * regs->pc;
       regcache->raw_collect (regs->pc, (void *)buf);
 
-      /* base(badvaddr) = regsize * regs->badvaddr */
+      /* Size base(badvaddr) = regsize * regs->badvaddr. */
       buf = (gdb_byte *)gprs + regsize * regs->badvaddr;
       regcache->raw_collect (regs->badvaddr, (void *)buf);
     }
@@ -113,13 +113,14 @@ loongarch_fill_elf_gregset (const struct regset *r,
           ||(regs->pc == regno)
           ||(regs->badvaddr == regno))
     {
-    /* offset(regno) = regsize * (regno - regs->r) */
+    /* Offset offset(regno) = regsize * (regno - regs->r). */
     buf = (gdb_byte *)gprs + regsize * (regno - regs->r);
     regcache->raw_collect (regno, (void *)buf);
     }
 }
 
-const struct regset loongarch_elf_gregset = {
+const struct regset loongarch_elf_gregset =
+{
   NULL,
   loongarch_supply_elf_gregset,
   loongarch_fill_elf_gregset,
@@ -146,7 +147,7 @@ loongarch_supply_elf_fpregset (const struct regset *r,
       regcache->raw_supply (regs->f + i, (const void *)buf);
       }
 
-    /* 8 fccs , base(fcc) = 32 * sizeof(fpr) */
+    /* 8 fccs , base(fcc) = 32 * sizeof(fpr). */
     buf = (const gdb_byte *)fprs + fprsize * 32;
     for (int i = 0; i < 8; i++)
       {
@@ -154,25 +155,25 @@ loongarch_supply_elf_fpregset (const struct regset *r,
       buf += fccsize;
       }
 
-    /* base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc) */
+    /* Size base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc). */
     buf = (const gdb_byte *)fprs + 32 * fprsize + 8 * fccsize;
     regno = regs->fcsr;
     }
   else if (regs->f <= regno && regno < regs->f + 32)
     {
-    /* offset(regno - f) = (regno - regs->f) * sizeof(fpr) */
+    /* Offset offset(regno - f) = (regno - regs->f) * sizeof(fpr). */
     buf = (const gdb_byte *)fprs + fprsize * (regno - regs->f);
     }
   else if (regs->fcc <= regno && regno < regs->fcc + 8)
     {
-    /* base(fcc) + offset(regno - fcc) =
-       32 * sizeof(fpr) + (regno - regs->fcc) * sizeof(fcc) */
+    /* Size base(fcc) + offset(regno - fcc) =
+       32 * sizeof(fpr) + (regno - regs->fcc) * sizeof(fcc). */
     buf = (const gdb_byte *)fprs + 32 * fprsize +
           (regno - regs->fcc) * fccsize;
     }
   else if (regs->fcsr == regno)
     {
-    /* base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc) */
+    /* Size base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc). */
     buf = (const gdb_byte *)fprs + 32 * fprsize + 8 * fccsize;
     }
   else
@@ -180,7 +181,7 @@ loongarch_supply_elf_fpregset (const struct regset *r,
     return;
     }
 
-    /* supply register */
+    /* Supply register. */
     regcache->raw_supply (regno, (const void *)buf);
 }
 
@@ -197,14 +198,14 @@ loongarch_fill_elf_fpregset (const struct regset *r,
 
   if (regno == -1)
     {
-    /* 32 fprs */
+    /* 32 fprs. */
     for (int i = 0; i < 32; i++)
       {
       buf = (gdb_byte *)fprs + fprsize * i;
       regcache->raw_collect (regs->f + i, (void *)buf);
       }
 
-      /* 8 fccs , base(fcc) = 32 * sizeof(fpr) */
+      /* 8 fccs , base(fcc) = 32 * sizeof(fpr). */
       buf = (gdb_byte *)fprs + fprsize * 32;
       for (int i = 0; i < 8; i++)
         {
@@ -212,24 +213,24 @@ loongarch_fill_elf_fpregset (const struct regset *r,
         buf += fccsize;
         }
 
-      /* base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc) */
+      /* Size base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc). */
       buf = (gdb_byte *)fprs + fprsize * 32 + fccsize * 8;
       regno = regs->fcsr;
     }
   else if (regs->f <= regno && regno < regs->f + 32)
     {
-    /* offset(regno - f) = (regno - regs->f) * sizeof(fpr) */
+    /* Offset offset(regno - f) = (regno - regs->f) * sizeof(fpr). */
     buf = (gdb_byte *)fprs + fprsize * (regno - regs->f);
     }
   else if (regs->fcc <= regno && regno < regs->fcc + 8)
     {
-    /* base(fcc) + offset(regno - fcc) =
-       32 * sizeof(fpr) + (regno - regs->fcc) * sizeof(fcc) */
+    /* Size base(fcc) + offset(regno - fcc) =
+       32 * sizeof(fpr) + (regno - regs->fcc) * sizeof(fcc). */
     buf = (gdb_byte *)fprs + 32 * fprsize + (regno - regs->fcc) * fccsize;
     }
   else if (regs->fcsr == regno)
     {
-    /* base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc) */
+    /* Size base(fcsr) = 32 * sizeof(fpr) + 8 * sizeof(fcc). */
     buf = (gdb_byte *)fprs + 32 * fprsize + 8 * fccsize;
     }
   else
@@ -237,11 +238,12 @@ loongarch_fill_elf_fpregset (const struct regset *r,
     return;
     }
 
-    /* supply register */
+    /* Supply register. */
     regcache->raw_collect (regno, (void *)buf);
 }
 
-const struct regset loongarch_elf_fpregset = {
+const struct regset loongarch_elf_fpregset =
+{
   NULL,
   loongarch_supply_elf_fpregset,
   loongarch_fill_elf_fpregset,
@@ -267,7 +269,8 @@ loongarch_fill_elf_cpucfgregset (const struct regset *r,
   memset ((gdb_byte *) cpucfgs + xfered_len, 0, len - xfered_len);
 }
 
-const struct regset loongarch_elf_cpucfgregset = {
+const struct regset loongarch_elf_cpucfgregset =
+{
   NULL,
   loongarch_supply_elf_cpucfgregset,
   loongarch_fill_elf_cpucfgregset,
@@ -287,30 +290,30 @@ loongarch_supply_elf_lbtregset (const struct regset *r,
 
   if (regno == -1)
     {
-    /* 4 scrs */
+    /* 4 scrs. */
     for (int i = 0; i < 4; i++)
       {
       buf = (const gdb_byte *)lbtrs + scrsize * i;
       regcache->raw_supply (regs->scr + i, (const void *)buf);
       }
 
-      /* base(EFLAG) = 4 * sizeof(scr) */
+      /* Size base(EFLAG) = 4 * sizeof(scr). */
       buf = (const gdb_byte *)lbtrs + scrsize * 4;
       regcache->raw_supply (regs->EFLAG, (const void *)buf);
 
-      /* base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG) */
+      /* Size base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG). */
       buf = (const gdb_byte *)lbtrs + scrsize * 4 + efsize;
       regno = regs->x86_top;
     }
   else if (regs->scr <= regno && regno < regs->scr + 4)
-    /* offset(EFLAG) = sizeof(scr) * (regno - regs->scr) */
+    /* Offset offset(EFLAG) = sizeof(scr) * (regno - regs->scr). */
     buf = (const gdb_byte *)lbtrs + scrsize * (regno - regs->scr);
   else if (regs->EFLAG == regno)
-    /* base(EFLAG) = 4 * sizeof(scr) */
+    /* Size base(EFLAG) = 4 * sizeof(scr). */
     buf = (const gdb_byte *)lbtrs + scrsize * 4;
   else if (regs->x86_top == regno)
     {
-    /* base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG) */
+    /* Size base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG). */
     buf = (const gdb_byte *)lbtrs + scrsize * 4 + efsize;
     }
   else
@@ -336,29 +339,29 @@ loongarch_fill_elf_lbtregset (const struct regset *r,
   if (regno == -1)
     {
 
-    /* 4 scrs */
+    /* 4 scrs. */
     for (int i = 0; i < 4; i++)
       {
       buf = (gdb_byte *)lbtrs + scrsize * i;
       regcache->raw_collect (regs->scr + i, (void *)buf);
       }
 
-      /* base(EFLAG) = 4 * sizeof(scr) */
+      /* Size base(EFLAG) = 4 * sizeof(scr). */
       buf = (gdb_byte *)lbtrs + scrsize * 4;
       regcache->raw_collect (regs->EFLAG, (void *)buf);
 
-      /* base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG) */
+      /* Size base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG). */
       buf = (gdb_byte *)lbtrs + scrsize * 4 + efsize;
       regno = regs->x86_top;
     }
   else if (regs->scr <= regno && regno < regs->scr + 4)
-    /* offset(EFLAG) = sizeof(scr) * (regno - regs->scr) */
+    /* Offset offset(EFLAG) = sizeof(scr) * (regno - regs->scr). */
     buf = (gdb_byte *)lbtrs + scrsize * (regno - regs->scr);
   else if (regs->EFLAG == regno)
-    /* base(EFLAG) = 4 * sizeof(scr) */
+    /* Size base(EFLAG) = 4 * sizeof(scr). */
     buf = (gdb_byte *)lbtrs + scrsize * 4;
   else if (regs->x86_top == regno)
-    /* base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG) */
+    /* Size base(x86_top) = 4 * sizeof(scr) + sizeof(EFLAG). */
     buf = (gdb_byte *)lbtrs + scrsize * 4 + efsize;
   else
     {
@@ -368,7 +371,8 @@ loongarch_fill_elf_lbtregset (const struct regset *r,
   regcache->raw_collect (regno, (void *)buf);
 }
 
-const struct regset loongarch_elf_lbtregset = {
+const struct regset loongarch_elf_lbtregset =
+{
   NULL,
   loongarch_supply_elf_lbtregset,
   loongarch_fill_elf_lbtregset,
@@ -426,7 +430,8 @@ loongarch_fill_elf_lsxregset (const struct regset *r,
     }
 }
 
-const struct regset loongarch_elf_lsxregset = {
+const struct regset loongarch_elf_lsxregset =
+{
   NULL,
   loongarch_supply_elf_lsxregset,
   loongarch_fill_elf_lsxregset,
@@ -484,7 +489,8 @@ loongarch_fill_elf_lasxregset (const struct regset *r,
     }
 }
 
-const struct regset loongarch_elf_lasxregset = {
+const struct regset loongarch_elf_lasxregset =
+{
   NULL,
   loongarch_supply_elf_lasxregset,
   loongarch_fill_elf_lasxregset,
@@ -570,10 +576,11 @@ loongarch_linux_lp64_sigframe_init (const struct tramp_frame *self,
   trad_frame_set_id (this_cache, frame_id_build (frame_sp, func));
 }
 
-static const struct tramp_frame loongarch_linux_lp64_rt_sigframe = {
+static const struct tramp_frame loongarch_linux_lp64_rt_sigframe =
+{
   SIGTRAMP_FRAME,
   4,
-  { /* from $kernel/arch/loongarch/vdso/sigreturn.S */
+  { /* From $kernel/arch/loongarch/vdso/sigreturn.S. */
     { 0x03822c0b, ULONGEST_MAX }, /* ori	$r11, $r0, 0x8b(__NR_rt_sigreturn) */
     { 0x002b0000, ULONGEST_MAX }, /* syscall	0 */
     { TRAMP_SENTINEL_INSN, ULONGEST_MAX } },

--- a/gdb/loongarch-linux-tdep.h
+++ b/gdb/loongarch-linux-tdep.h
@@ -32,10 +32,10 @@ extern const struct regset loongarch_elf_gregset;
 typedef uint64_t loongarch_elf_fpregset_t[ELF_NFPREG];
 extern const struct regset loongarch_elf_fpregset;
 
-/* regset variable size */
+/* Regset variable size. */
 extern const struct regset loongarch_elf_cpucfg;
 
-/* 4 SCRs + 4-byte EFLAG + 1-byte x86_top */
+/* 4 SCRs + 4-byte EFLAG + 1-byte x86_top. */
 typedef uint64_t loongarch_elf_lbtregset_t[5];
 extern const struct regset loongarch_elf_lbtregset;
 

--- a/gdb/loongarch-tdep.c
+++ b/gdb/loongarch-tdep.c
@@ -1352,8 +1352,8 @@ typedef BP_MANIPULATION (loongarch_default_breakpoint) loongarch_breakpoint;
    Called e.g. at program startup, when reading a core file, and when
    reading a binary file.  */
 
-/* This predicate tests whether we need to read lsx/lasx registers 
-   (instead of fp registers with the same DWARF2 code 
+/* This predicate tests whether we need to read lsx/lasx registers
+   (instead of fp registers with the same DWARF2 code
    (thus the same internal code, though lasx/lsx/fp reg internal codes are different))
    according to the byte-size of requested type. */
 
@@ -1363,10 +1363,10 @@ loongarch_fp_regnum_refers_to_lsx_lasx_p (struct gdbarch *gdbarch, int regnum,
 {
   /* Conditions:
        1) regnum is in "disputed" zone (fp/lsx/lasx, translated from dwarf regnum)
-       2) type is larger than 8 bytes 
+       2) type is larger than 8 bytes
 
-      (if specified type is larger than 8 bytes, 
-       then regnum refers to lsx / lasx register instead of fp register) 
+      (if specified type is larger than 8 bytes,
+       then regnum refers to lsx / lasx register instead of fp register)
     */
   return regnum >= gdbarch_tdep (gdbarch)->regs.f &&
          regnum < gdbarch_tdep (gdbarch)->regs.f + 32 &&

--- a/gdbserver/linux-loongarch-low.cc
+++ b/gdbserver/linux-loongarch-low.cc
@@ -249,7 +249,8 @@ loongarch_store_lasxregset (struct regcache *regcache, const void *buf)
     supply_register (regcache, xr + i, (const uint64_t *) buf + 4 * i);
 }
 
-static struct regset_info loongarch_regsets[] = {
+static struct regset_info loongarch_regsets[] =
+{
   { PTRACE_GETREGSET, PTRACE_SETREGSET, NT_PRSTATUS, 33 * 8, GENERAL_REGS,
     loongarch_fill_gregset, loongarch_store_gregset },
   { PTRACE_GETREGSET, PTRACE_SETREGSET, NT_FPREGSET, 34 * 8, FP_REGS,
@@ -263,7 +264,7 @@ static struct regset_info loongarch_regsets[] = {
   NULL_REGSET
 };
 
-static struct regsets_info loongarch_regsets_info = 
+static struct regsets_info loongarch_regsets_info =
 {
   loongarch_regsets, /* regsets */
   0,                 /* num_regsets */

--- a/include/elf/loongarch.h
+++ b/include/elf/loongarch.h
@@ -24,7 +24,7 @@
 #include "libiberty.h"
 
 START_RELOC_NUMBERS (elf_loongarch_reloc_type)
-/* used by the dynamic linker */
+/* Used by the dynamic linker. */
 RELOC_NUMBER (R_LARCH_NONE, 0)
 RELOC_NUMBER (R_LARCH_32, 1)
 RELOC_NUMBER (R_LARCH_64, 2)
@@ -41,7 +41,7 @@ RELOC_NUMBER (R_LARCH_IRELATIVE, 12)
 
 /* Reserved for future relocs that the dynamic linker must understand.  */
 
-/* used by the static linker for relocating .text */
+/* Used by the static linker for relocating .text. */
 RELOC_NUMBER (R_LARCH_MARK_LA, 20)
 RELOC_NUMBER (R_LARCH_MARK_PCREL, 21)
 
@@ -74,7 +74,7 @@ RELOC_NUMBER (R_LARCH_SOP_POP_32_S_0_5_10_16_S2, 44)
 RELOC_NUMBER (R_LARCH_SOP_POP_32_S_0_10_10_16_S2, 45)
 RELOC_NUMBER (R_LARCH_SOP_POP_32_U, 46)
 
-/* used by the static linker for relocating non .text */
+/* Used by the static linker for relocating non .text. */
 RELOC_NUMBER (R_LARCH_ADD8, 47)
 RELOC_NUMBER (R_LARCH_ADD16, 48)
 RELOC_NUMBER (R_LARCH_ADD24, 49)

--- a/include/opcode/loongarch.h
+++ b/include/opcode/loongarch.h
@@ -37,10 +37,10 @@ extern "C"
 #define LARCH_INSN_OPC(insn) ((insn & 0xf0000000) >> 28)
     const char *const name;
 
-    /* 
+    /*
      ACTUAL PARAMETER:
 
-  // BNF with regular expression. 
+  // BNF with regular expression.
 args : token* end
 
   // just few char separate 'iden'
@@ -63,7 +63,7 @@ That 'sr' means the instruction may need relocate. '10:16' means bit field of in
 In a 'format', every 'escape's can be replaced to 'iden' or 'regname' acrroding to its meaning.
 We fill all information needed by disassembing and assembing to 'format'.
 
-  // BNF with regular expression. 
+  // BNF with regular expression.
 format : escape (literal+ escape)* literal* end
 | (literal+ escape)* literal* end
 
@@ -80,8 +80,8 @@ escape : esc_ch bit_field '<' '<' dec2
 | esc_ch bit_field
 | esc_ch    // for MACRO. non-macro format must indicate 'bit_field'
 
-  // '|' means to concatenate nonadjacent bit fields 
-  // For example, "10:16|0:4" means 
+  // '|' means to concatenate nonadjacent bit fields
+  // For example, "10:16|0:4" means
   // "16 bits starting from the 10th bit concatenating with 4 bits starting from the 0th bit".
   // This is to say "[25..10]||[3..0]" (little endian).
 b_field : dec2 ':' dec2
@@ -106,7 +106,7 @@ dec2 : [1-9][0-9]?
 MACRO: Indicate how a macro instruction expand for assembling.
 The main is to replace the '%num'(means the 'num'th 'escape' in 'format') in 'macro' string to get the real instruction.
 
-Maybe need 
+Maybe need
 */
     const char *const macro;
     const int *include;
@@ -125,11 +125,11 @@ Maybe need
     const int *include;
     const int *exclude;
 
-    /* for disassemble to create main opcode hash table. */
+    /* For disassemble to create main opcode hash table. */
     const struct loongarch_opcode *opc_htab[16];
     unsigned char opc_htab_inited;
 
-    /* for GAS to create hash table. */
+    /* For GAS to create hash table. */
     struct htab *name_hash_entry;
   };
 

--- a/ld/NEWS
+++ b/ld/NEWS
@@ -1,5 +1,9 @@
 -*- text -*-
 
+Changes in 2.37:
+
+* Add support for the LoongArch instruction set.
+
 * Add -z indirect-extern-access/-z noindirect-extern-access to x86 ELF
   linker to control canonical function pointers and copy relocation.
 

--- a/opcodes/loongarch-coder.c
+++ b/opcodes/loongarch-coder.c
@@ -234,7 +234,7 @@ loongarch_encode_imm (const char *bit_field, int32_t imm)
   return ret;
 }
 
-/* parse such FORMAT
+/* Parse such FORMAT
      ""
      "u"
      "v0:5,r5:5,s10:10<<2"
@@ -269,14 +269,14 @@ loongarch_parse_format (const char *format, char *esc1s, char *esc2s,
 
       arg_num++;
       if (MAX_ARG_NUM_PLUS_2 - 2 < arg_num)
-        /* need larger MAX_ARG_NUM_PLUS_2 */
+        /* Need larger MAX_ARG_NUM_PLUS_2. */
         return -1;
 
       *bit_fields++ = format;
 
       if ('0' <= *format && *format <= '9')
         {
-          /* for "[0-9]+:[0-9]+(\|[0-9]+:[0-9]+)*" */
+          /* For "[0-9]+:[0-9]+(\|[0-9]+:[0-9]+)*". */
           while (1)
             {
               while ('0' <= *format && *format <= '9')
@@ -296,7 +296,7 @@ loongarch_parse_format (const char *format, char *esc1s, char *esc2s,
               format++;
             }
 
-          /* for "((\+|<<)[1-9][0-9]*)?" */
+          /* For "((\+|<<)[1-9][0-9]*)?". */
           do
             {
               if (*format == '+')
@@ -378,7 +378,7 @@ loongarch_foreach_args (const char *format, const char *arg_strs[],
 
   ok = loongarch_parse_format (format, esc1s, esc2s, bit_fields) == 0;
 
-  /* make sure the num of actual args is equal to the num of escape */
+  /* Make sure the num of actual args is equal to the num of escape. */
   for (i = 0; esc1s[i] && arg_strs[i]; i++)
     ;
   ok = ok && !esc1s[i] && !arg_strs[i];
@@ -428,7 +428,7 @@ loongarch_check_macro (const char *format, const char *macro)
         if ('1' <= macro[0] && macro[0] <= '9')
           {
             if (num_of_args < macro[0] - '0')
-              /* out of args num */
+              /* Out of args num. */
               return -1;
           }
         else if (macro[0] == 'f')

--- a/opcodes/loongarch-dis.c
+++ b/opcodes/loongarch-dis.c
@@ -321,7 +321,8 @@ loongarch_disassemble_one (int64_t pc, insn_t insn,
                                                 const char *format, ...),
                            void *stream)
 {
-  static struct disassemble_info my_disinfo = {
+  static struct disassemble_info my_disinfo =
+  {
     .print_address_func = my_print_address_func,
   };
   static int not_init_yet = 1;

--- a/opcodes/loongarch-opc.c
+++ b/opcodes/loongarch-opc.c
@@ -21,7 +21,7 @@
 #include <stddef.h>
 #include "opcode/loongarch.h"
 
-struct loongarch_ASEs_option LARCH_opts = 
+struct loongarch_ASEs_option LARCH_opts =
 {
   .ase_test = 0,
   .ase_fix = 0,
@@ -47,7 +47,7 @@ loongarch_insn_length (insn_t insn)
   return insn ? 4 : 4; /* eliminate warning */
 }
 
-const char *const loongarch_r_normal_name[32] = 
+const char *const loongarch_r_normal_name[32] =
 {
   "$r0",  "$r1",  "$r2",  "$r3",  "$r4",  "$r5",  "$r6",  "$r7",
   "$r8",  "$r9",  "$r10", "$r11", "$r12", "$r13", "$r14", "$r15",
@@ -55,7 +55,7 @@ const char *const loongarch_r_normal_name[32] =
   "$r24", "$r25", "$r26", "$r27", "$r28", "$r29", "$r30", "$r31",
 };
 
-const char *const loongarch_r_lp64_name[32] = 
+const char *const loongarch_r_lp64_name[32] =
 {
   "$zero", "$ra", "$tp", "$sp", "$a0", "$a1", "$a2", "$a3",
   "$a4",   "$a5", "$a6", "$a7", "$t0", "$t1", "$t2", "$t3",
@@ -63,13 +63,13 @@ const char *const loongarch_r_lp64_name[32] =
   "$s1",   "$s2", "$s3", "$s4", "$s5", "$s6", "$s7", "$s8",
 };
 
-const char *const loongarch_r_lp64_name1[32] = 
+const char *const loongarch_r_lp64_name1[32] =
 {
   "", "", "", "", "$v0", "$v1", "", "", "", "", "", "", "", "", "", "",
   "", "", "", "", "",    "",    "", "", "", "", "", "", "", "", "", "",
 };
 
-const char *const loongarch_f_normal_name[32] = 
+const char *const loongarch_f_normal_name[32] =
 {
   "$f0",  "$f1",  "$f2",  "$f3",  "$f4",  "$f5",  "$f6",  "$f7",
   "$f8",  "$f9",  "$f10", "$f11", "$f12", "$f13", "$f14", "$f15",
@@ -77,7 +77,7 @@ const char *const loongarch_f_normal_name[32] =
   "$f24", "$f25", "$f26", "$f27", "$f28", "$f29", "$f30", "$f31",
 };
 
-const char *const loongarch_f_lp64_name[32] = 
+const char *const loongarch_f_lp64_name[32] =
 {
   "$fa0", "$fa1", "$fa2",  "$fa3",  "$fa4",  "$fa5",  "$fa6",  "$fa7",
   "$ft0", "$ft1", "$ft2",  "$ft3",  "$ft4",  "$ft5",  "$ft6",  "$ft7",
@@ -85,18 +85,18 @@ const char *const loongarch_f_lp64_name[32] =
   "$fs0", "$fs1", "$fs2",  "$fs3",  "$fs4",  "$fs5",  "$fs6",  "$fs7",
 };
 
-const char *const loongarch_f_lp64_name1[32] = 
+const char *const loongarch_f_lp64_name1[32] =
 {
   "$fv0", "$fv1", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
   "",     "",     "", "", "", "", "", "", "", "", "", "", "", "", "", "",
 };
 
-const char *const loongarch_c_normal_name[8] = 
+const char *const loongarch_c_normal_name[8] =
 {
   "$fcc0", "$fcc1", "$fcc2", "$fcc3", "$fcc4", "$fcc5", "$fcc6", "$fcc7",
 };
 
-const char *const loongarch_cr_normal_name[4] = 
+const char *const loongarch_cr_normal_name[4] =
 {
   "$scr0",
   "$scr1",
@@ -104,7 +104,7 @@ const char *const loongarch_cr_normal_name[4] =
   "$scr3",
 };
 
-const char *const loongarch_v_normal_name[32] = 
+const char *const loongarch_v_normal_name[32] =
 {
   "$vr0",  "$vr1",  "$vr2",  "$vr3",  "$vr4",  "$vr5",  "$vr6",  "$vr7",
   "$vr8",  "$vr9",  "$vr10", "$vr11", "$vr12", "$vr13", "$vr14", "$vr15",
@@ -112,7 +112,7 @@ const char *const loongarch_v_normal_name[32] =
   "$vr24", "$vr25", "$vr26", "$vr27", "$vr28", "$vr29", "$vr30", "$vr31",
 };
 
-const char *const loongarch_x_normal_name[32] = 
+const char *const loongarch_x_normal_name[32] =
 {
   "$xr0",  "$xr1",  "$xr2",  "$xr3",  "$xr4",  "$xr5",  "$xr6",  "$xr7",
   "$xr8",  "$xr9",  "$xr10", "$xr11", "$xr12", "$xr13", "$xr14", "$xr15",
@@ -120,7 +120,7 @@ const char *const loongarch_x_normal_name[32] =
   "$xr24", "$xr25", "$xr26", "$xr27", "$xr28", "$xr29", "$xr30", "$xr31",
 };
 
-static struct loongarch_opcode loongarch_macro_opcodes[] = 
+static struct loongarch_opcode loongarch_macro_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   {0, 0, "li.w", "r,sc", "%f", 0, 0, 0},
@@ -276,7 +276,7 @@ static struct loongarch_opcode loongarch_macro_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-static struct loongarch_opcode loongarch_fix_opcodes[] = 
+static struct loongarch_opcode loongarch_fix_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   { 0x00001000, 0xfffffc00, "clo.w", "r0:5,r5:5", 0, 0, 0, 0 },
@@ -375,7 +375,7 @@ static struct loongarch_opcode loongarch_fix_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-static struct loongarch_opcode loongarch_float_opcodes[] = 
+static struct loongarch_opcode loongarch_float_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   { 0x01008000, 0xffff8000, "fadd.s", "f0:5,f5:5,f10:5", 0, 0, 0, 0 },
@@ -457,7 +457,7 @@ static struct loongarch_opcode loongarch_float_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-static struct loongarch_opcode loongarch_lmm_opcodes[] = 
+static struct loongarch_opcode loongarch_lmm_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   { 0x02000000, 0xffc00000, "slti", "r0:5,r5:5,s10:12", 0, 0, 0, 0 },
@@ -479,7 +479,7 @@ static struct loongarch_opcode loongarch_lmm_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-static struct loongarch_opcode loongarch_privilege_opcodes[] = 
+static struct loongarch_opcode loongarch_privilege_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   { 0x04000000, 0xff0003e0, "csrrd", "r0:5,u10:14", 0, 0, 0, 0 },
@@ -508,7 +508,7 @@ static struct loongarch_opcode loongarch_privilege_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-static struct loongarch_opcode loongarch_4opt_opcodes[] = 
+static struct loongarch_opcode loongarch_4opt_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   { 0x08100000, 0xfff00000, "fmadd.s", "f0:5,f5:5,f10:5,f15:5", 0, 0, 0, 0 },
@@ -575,7 +575,7 @@ static struct loongarch_opcode loongarch_4opt_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-static struct loongarch_opcode loongarch_load_store_opcodes[] = 
+static struct loongarch_opcode loongarch_load_store_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   { 0x20000000, 0xff000000, "ll.w", "r0:5,r5:5,s10:14<<2", 0, 0, 0, 0 },
@@ -719,7 +719,7 @@ static struct loongarch_opcode loongarch_load_store_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-static struct loongarch_opcode loongarch_jmp_opcodes[] = 
+static struct loongarch_opcode loongarch_jmp_opcodes[] =
 {
   /* match,    mask,       name, format, macro, include, exclude, pinfo */
   { 0, 0, "bltz", "r,la", "bltz %1,%%pcrel(%2)", 0, 0, 0 },
@@ -767,7 +767,7 @@ static struct loongarch_opcode loongarch_jmp_opcodes[] =
   { 0 } /* Terminate the list.  */
 };
 
-struct loongarch_ase loongarch_ASEs[] = 
+struct loongarch_ase loongarch_ASEs[] =
 {
   { &LARCH_opts.ase_fix, loongarch_macro_opcodes, 0, 0, { 0 }, 0, 0 },
   { &LARCH_opts.ase_fix, loongarch_lmm_opcodes, 0, 0, { 0 }, 0, 0 },


### PR DESCRIPTION
  bfd/cpu-loongarch.c
  bfd/elfnn-loongarch.c
  bfd/elfxx-loongarch.c
  gas/NEWS
  gas/config/loongarch-parse.y
  gas/config/tc-loongarch.c
  gas/config/tc-loongarch.h
  gas/doc/as.texi
  gas/doc/c-loongarch.texi
  gas/testsuite/gas/loongarch/loongarch.exp
  gas/testsuite/gas/loongarch/nop.d
  gas/testsuite/gas/loongarch/nop.s
  gdb/arch/loongarch-linux-nat.c
  gdb/loongarch-linux-nat.c
  gdb/loongarch-linux-tdep.c
  gdb/loongarch-linux-tdep.h
  gdb/loongarch-tdep.c
  gdbserver/linux-loongarch-low.cc
  include/elf/loongarch.h
  include/opcode/loongarch.h
  ld/NEWS
  opcodes/loongarch-coder.c
  opcodes/loongarch-dis.c
  opcodes/loongarch-opc.c