### PR TITLE
binutils: rename L/loongarch to LoongArch

### DIFF
--- a/bfd/archures.c
+++ b/bfd/archures.c
@@ -555,7 +555,7 @@ DESCRIPTION
 .#define bfd_mach_ck807		6
 .#define bfd_mach_ck810		7
 .#define bfd_mach_ck860		8
-.  bfd_arch_loongarch,       {* Loongarch *}
+.  bfd_arch_loongarch,       {* LoongArch *}
 .#define bfd_mach_loongarch32	1
 .#define bfd_mach_loongarch64	2
 .  bfd_arch_last

--- a/bfd/bfd-in2.h
+++ b/bfd/bfd-in2.h
@@ -1932,7 +1932,7 @@ enum bfd_architecture
 #define bfd_mach_ck807         6
 #define bfd_mach_ck810         7
 #define bfd_mach_ck860         8
-  bfd_arch_loongarch,       /* Loongarch */
+  bfd_arch_loongarch,       /* LoongArch */
 #define bfd_mach_loongarch32   1
 #define bfd_mach_loongarch64   2
   bfd_arch_last

--- a/bfd/cpu-loongarch.c
+++ b/bfd/cpu-loongarch.c
@@ -1,4 +1,4 @@
-/* BFD support for Loongarch.
+/* BFD support for LoongArch.
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
 
@@ -46,8 +46,8 @@ const bfd_arch_info_type bfd_loongarch_arch =
   64,				/* 64 bits in an address.  */
   8,				/* 8 bits in a byte.  */
   bfd_arch_loongarch,		/* Architecture.  */
-  /* Machine number of loongarch64 is larger
-   * so that loongarch64 is compatible to loongarch32.  */
+  /* Machine number of LoongArch64 is larger
+   * so that LoongArch64 is compatible to LoongArch32.  */
   bfd_mach_loongarch64,
   "loongarch64",		/* Architecture name.  */
   "Loongarch64",		/* Printable name.  */

--- a/bfd/elfnn-loongarch.c
+++ b/bfd/elfnn-loongarch.c
@@ -1,4 +1,4 @@
-/* Loongarch-specific support for NN-bit ELF.
+/* LoongArch-specific support for NN-bit ELF.
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
 
@@ -37,7 +37,7 @@ loongarch_info_to_howto_rela (bfd *abfd ATTRIBUTE_UNUSED, arelent *cache_ptr,
   return cache_ptr->howto != NULL;
 }
 
-/* Loongarch ELF linker hash entry.  */
+/* LoongArch ELF linker hash entry.  */
 struct loongarch_elf_link_hash_entry
 {
   struct elf_link_hash_entry elf;
@@ -96,7 +96,7 @@ struct loongarch_elf_link_hash_table
   bfd_vma max_alignment;
 };
 
-/* Get the Loongarch ELF linker hash table from a link_info structure.  */
+/* Get the LoongArch ELF linker hash table from a link_info structure.  */
 #define loongarch_elf_hash_table(p)					\
   (elf_hash_table_id ((struct elf_link_hash_table *) ((p)->hash))	\
     == LARCH_ELF_DATA							\
@@ -202,7 +202,7 @@ loongarch_make_plt_entry (bfd_vma got_plt_entry_addr, bfd_vma plt_entry_addr,
   /* entry[3] = 0x4c0001e0; */ /* jirl $r0, $15, 0 */
 }
 
-/* Create an entry in an Loongarch ELF linker hash table.  */
+/* Create an entry in an LoongArch ELF linker hash table.  */
 
 static struct bfd_hash_entry *
 link_hash_newfunc (struct bfd_hash_entry *entry, struct bfd_hash_table *table,
@@ -304,7 +304,7 @@ elfNN_loongarch_get_local_sym_hash (struct loongarch_elf_link_hash_table *htab,
   return &ret->elf;
 }
 
-/* Destroy an Loongarch elf linker hash table.  */
+/* Destroy an LoongArch elf linker hash table.  */
 
 static void
 elfNN_loongarch_link_hash_table_free (bfd *obfd)
@@ -320,7 +320,7 @@ elfNN_loongarch_link_hash_table_free (bfd *obfd)
   _bfd_elf_link_hash_table_free (obfd);
 }
 
-/* Create a Loongarch ELF linker hash table.  */
+/* Create a LoongArch ELF linker hash table.  */
 
 static struct bfd_link_hash_table *
 loongarch_elf_link_hash_table_create (bfd *abfd)
@@ -2980,7 +2980,7 @@ loongarch_elf_grok_prstatus (bfd *abfd, Elf_Internal_Note *note)
       return false;
 
     case sizeof (
-      prstatus_t): /* The sizeof(struct elf_prstatus) on Linux/Loongarch.  */
+      prstatus_t): /* The sizeof(struct elf_prstatus) on Linux/LoongArch.  */
       /* pr_cursig  */
       elf_tdata (abfd)->core->signal =
 	bfd_get_16 (abfd, note->descdata + offsetof (prstatus_t, pr_cursig));
@@ -3006,7 +3006,7 @@ loongarch_elf_grok_psinfo (bfd *abfd, Elf_Internal_Note *note)
       return false;
 
     case sizeof (
-      prpsinfo_t): /* sizeof(struct elf_prpsinfo) on Linux/Loongarch.  */
+      prpsinfo_t): /* sizeof(struct elf_prpsinfo) on Linux/LoongArch.  */
       /* pr_pid  */
       elf_tdata (abfd)->core->pid =
 	bfd_get_32 (abfd, note->descdata + offsetof (prpsinfo_t, pr_pid));
@@ -3042,7 +3042,7 @@ loongarch_elf_grok_psinfo (bfd *abfd, Elf_Internal_Note *note)
 static bool
 loongarch_elf_object_p (bfd *abfd)
 {
-  /* There are only two mach types in Loongarch currently.  */
+  /* There are only two mach types in LoongArch currently.  */
   if (strcmp (abfd->xvec->name, "elf64-loongarch") == 0)
     bfd_default_set_arch_mach (abfd, bfd_arch_loongarch, bfd_mach_loongarch64);
   else

--- a/bfd/elfxx-loongarch.c
+++ b/bfd/elfxx-loongarch.c
@@ -1,4 +1,4 @@
-/* Loongarch-specific support for ELF.
+/* LoongArch-specific support for ELF.
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
 

--- a/bfd/elfxx-loongarch.h
+++ b/bfd/elfxx-loongarch.h
@@ -1,4 +1,4 @@
-/* Loonarch-specific backend routines.
+/* LoongArch-specific backend routines.
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
 

--- a/gas/Makefile.am
+++ b/gas/Makefile.am
@@ -473,7 +473,7 @@ config/rx-parse.c: $(srcdir)/config/rx-parse.y
 config/rx-parse.h: config/rx-parse.c
 	@true
 
-# The loongarch lexical analyzer and parser.
+# The LoongArch lexical analyzer and parser.
 EXTRA_as_new_SOURCES += config/loongarch-parse.y
 loongarch-parse.c: $(srcdir)/config/loongarch-parse.y
 	$(SHELL) $(YLWRAP) $(srcdir)/config/loongarch-parse.y y.tab.c loongarch-parse.c y.tab.h loongarch-parse.h -- $(YACCCOMPILE) -d ;

--- a/gas/Makefile.in
+++ b/gas/Makefile.in
@@ -792,7 +792,7 @@ as_new_DEPENDENCIES = $(TARG_CPU_O) $(OBJ_FORMAT_O) $(ATOF_TARG_O) \
 	$(extra_objects) $(GASLIBS) $(LIBINTL_DEP)
 
 
-# The loongarch lexical analyzer and parser.
+# The LoongArch lexical analyzer and parser.
 EXTRA_as_new_SOURCES = $(CFILES) $(HFILES) $(TARGET_CPU_CFILES) \
 	$(TARGET_CPU_HFILES) $(TARGET_EXTRA_FILES) $(TARG_ENV_CFILES) \
 	$(OBJ_FORMAT_CFILES) $(OBJ_FORMAT_HFILES) \

--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -1,4 +1,4 @@
-/* tc-loongarch.c -- Assemble for the Loongarch ISA
+/* tc-loongarch.c -- Assemble for the LoongArch ISA
 
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.

--- a/gdb/configure.nat
+++ b/gdb/configure.nat
@@ -259,7 +259,7 @@ case ${gdb_host} in
 		NATDEPFILES="${NATDEPFILES} ia64-linux-nat.o"
 		;;
 	    loongarch)
-		# Host: Loongarch, running GNU/Linux.
+		# Host: LoongArch, running GNU/Linux.
 		NATDEPFILES="${NATDEPFILES} loongarch-linux-nat.o arch/loongarch-linux-nat.o linux-nat-trad.o nat/loongarch-linux-watch.o"
 		;;
 	    m32r)

--- a/gdb/loongarch-linux-nat.c
+++ b/gdb/loongarch-linux-nat.c
@@ -1,4 +1,4 @@
-/* Target-dependent code for GNU/Linux Loongarch.
+/* Target-dependent code for GNU/Linux LoongArch.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
@@ -867,9 +867,9 @@ _initialize_loongarch_linux_nat ()
 {
   add_setshow_boolean_cmd (
     "show-debug-regs", class_maintenance, &show_debug_regs, _ ("\
-Set whether to show variables that mirror the loongarch debug registers."),
+Set whether to show variables that mirror the LoongArch debug registers."),
     _ ("\
-Show whether to show variables that mirror the loongarch debug registers."),
+Show whether to show variables that mirror the LoongArch debug registers."),
     _ ("\
 Use \"on\" to enable, \"off\" to disable.\n\
 If enabled, the debug registers values are shown when GDB inserts\n\

--- a/gdb/loongarch-linux-tdep.c
+++ b/gdb/loongarch-linux-tdep.c
@@ -1,4 +1,4 @@
-/* Target-dependent code for GNU/Linux Loongarch.
+/* Target-dependent code for GNU/Linux LoongArch.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
@@ -520,21 +520,21 @@ loongarch_linux_iterate_over_regset_sections (
 			       &xfered_len) != TARGET_XFER_OK)
 	break;
       cb (".reg-loongarch-cpucfg", 64 * 4, 64 * 4, &loongarch_elf_cpucfgregset,
-	  "Loongarch CPU config", cb_data);
+	  "LoongArch CPU config", cb_data);
     }
   while (0);
   if (0 <= regs->scr)
     cb (".reg-loongarch-lbt", sizeof (loongarch_elf_lbtregset_t),
 	sizeof (loongarch_elf_lbtregset_t), &loongarch_elf_lbtregset,
-	"Loongson Binary Translation", cb_data);
+	"LoongArch Binary Translation", cb_data);
   if (0 <= regs->vr)
     cb (".reg-loongarch-lsx", sizeof (loongarch_elf_lsxregset_t),
 	sizeof (loongarch_elf_lsxregset_t), &loongarch_elf_lsxregset,
-	"Loongson SIMD Extension", cb_data);
+	"LoongArch SIMD Extension", cb_data);
   if (0 <= regs->xr)
     cb (".reg-loongarch-lasx", sizeof (loongarch_elf_lasxregset_t),
 	sizeof (loongarch_elf_lasxregset_t), &loongarch_elf_lasxregset,
-	"Loongson Advanced SIMD Extension", cb_data);
+	"LoongArch Advanced SIMD Extension", cb_data);
 }
 
 static const struct target_desc *

--- a/gdb/loongarch-linux-tdep.h
+++ b/gdb/loongarch-linux-tdep.h
@@ -1,4 +1,4 @@
-/* GNU/Linux on Loongarch target support, prototypes.
+/* GNU/Linux on LoongArch target support, prototypes.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.

--- a/gdb/loongarch-tdep.c
+++ b/gdb/loongarch-tdep.c
@@ -1,4 +1,4 @@
-/* Target-dependent code for GNU/Linux Loongarch.
+/* Target-dependent code for GNU/Linux LoongArch.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
@@ -270,7 +270,7 @@ loongarch_deal_with_atomic_sequence (struct regcache *regcache, CORE_ADDR pc)
   return next_pcs;
 }
 
-/* Implement loongarch software single step.  */
+/* Implement LoongArch software single step.  */
 
 std::vector<CORE_ADDR>
 loongarch_software_single_step (struct regcache *regcache);
@@ -1240,7 +1240,7 @@ loongarch_lp64_return_value (struct gdbarch *gdbarch, struct value *function,
        || (typecode == TYPE_CODE_STRUCT && type->num_fields () == 1
 	   && check_typedef (type->field (0).type ())->code ()
 		== TYPE_CODE_FLT))
-      && len <= rlen /* FIXME: May fpu32 on loongarch32.  */)
+      && len <= rlen /* FIXME: May fpu32 on LoongArch32.  */)
     /* If $fv0 could fit in.  */
     loongarch_xfer_reg_part (regcache, fv, len, readbuf, 0, writebuf, 0);
   else if ((typecode == TYPE_CODE_FLT
@@ -1319,7 +1319,7 @@ loongarch_lp64_return_value (struct gdbarch *gdbarch, struct value *function,
 			       0);
   else
     {
-      /* For small structure or int64_t on loongarch32.  */
+      /* For small structure or int64_t on LoongArch32.  */
       if (len <= rlen)
 	loongarch_xfer_reg_part (regcache, regs->r + 4, len, readbuf, 0,
 				 writebuf, 0);

--- a/gdb/loongarch-tdep.h
+++ b/gdb/loongarch-tdep.h
@@ -1,4 +1,4 @@
-/* Target-dependent code for GNU/Linux Loongarch.
+/* Target-dependent code for GNU/Linux LoongArch.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.

--- a/include/elf/common.h
+++ b/include/elf/common.h
@@ -679,15 +679,15 @@
 					/*   note name must be "LINUX".  */
 #define NT_RISCV_CSR    0x900		/* RISC-V Control and Status Registers */
 					/*   note name must be "LINUX".  */
-#define NT_LARCH_CPUCFG 0xa00		/* Loongarch CPU config registers */
+#define NT_LARCH_CPUCFG 0xa00		/* LoongArch CPU config registers */
 					/*   note name must be "LINUX".  */
-#define NT_LARCH_CSR    0xa01		/* Loongarch control state registers */
+#define NT_LARCH_CSR    0xa01		/* LoongArch control state registers */
 					/*   note name must be "LINUX".  */
-#define NT_LARCH_LSX    0xa02		/* Loongarch Loongson SIMD Extension registers */
+#define NT_LARCH_LSX    0xa02		/* LoongArch Loongson SIMD Extension registers */
 					/*   note name must be "LINUX".  */
-#define NT_LARCH_LASX   0xa03		/* Loongarch Loongson Advanced SIMD Extension registers */
+#define NT_LARCH_LASX   0xa03		/* LoongArch Loongson Advanced SIMD Extension registers */
 					/*   note name must be "LINUX".  */
-#define NT_LARCH_LBT    0xa04		/* Loongarch Loongson Binary Translation registers */
+#define NT_LARCH_LBT    0xa04		/* LoongArch Loongson Binary Translation registers */
 					/*   note name must be "CORE".  */
 #define NT_SIGINFO	0x53494749	/* Fields of siginfo_t.  */
 #define NT_FILE		0x46494c45	/* Description of mapped files.  */

--- a/include/opcode/loongarch.h
+++ b/include/opcode/loongarch.h
@@ -1,4 +1,4 @@
-/* Loongarch assembler/disassembler support.
+/* LoongArch assembler/disassembler support.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.

--- a/opcodes/disassemble.c
+++ b/opcodes/disassemble.c
@@ -49,7 +49,7 @@
 #define ARCH_ip2k
 #define ARCH_iq2000
 #define ARCH_lm32
-#define ARCH_loongarch
+#define ARCH_LoongArch
 #define ARCH_m32c
 #define ARCH_m32r
 #define ARCH_m68hc11
@@ -553,7 +553,7 @@ disassembler (enum bfd_architecture a,
       disassemble = print_insn_tilepro;
       break;
 #endif
-#ifdef ARCH_loongarch
+#ifdef ARCH_LoongArch
     case bfd_arch_loongarch:
       disassemble = print_insn_loongarch;
       break;
@@ -597,7 +597,7 @@ disassembler_usage (FILE *stream ATTRIBUTE_UNUSED)
 #ifdef ARCH_wasm32
   print_wasm32_disassembler_options (stream);
 #endif
-#ifdef ARCH_loongarch
+#ifdef ARCH_LoongArch
   print_loongarch_disassembler_options (stream);
 #endif
 

--- a/opcodes/loongarch-coder.c
+++ b/opcodes/loongarch-coder.c
@@ -1,4 +1,4 @@
-/* loongarch opcode support.
+/* LoongArch opcode support.
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
 

--- a/opcodes/loongarch-dis.c
+++ b/opcodes/loongarch-dis.c
@@ -1,4 +1,4 @@
-/* loongarch opcode support.
+/* LoongArch opcode support.
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
 

--- a/opcodes/loongarch-opc.c
+++ b/opcodes/loongarch-opc.c
@@ -1,4 +1,4 @@
-/* loongarch opcode support.
+/* LoongArch opcode support.
    Copyright (C) 2021 Free Software Foundation, Inc.
    Contributed by Loongson Ltd.
 


### PR DESCRIPTION
  bfd/archures.c
  bfd/bfd-in2.h
  bfd/cpu-loongarch.c
  bfd/elfnn-loongarch.c
  bfd/elfxx-loongarch.c
  bfd/elfxx-loongarch.h
  gas/Makefile.am
  gas/Makefile.in
  gas/config/tc-loongarch.c
  gdb/configure.nat
  gdb/loongarch-linux-nat.c
  gdb/loongarch-linux-tdep.c
  gdb/loongarch-linux-tdep.h
  gdb/loongarch-tdep.c
  gdb/loongarch-tdep.h
  include/elf/common.h
  include/opcode/loongarch.h
  opcodes/disassemble.c
  opcodes/loongarch-coder.c
  opcodes/loongarch-dis.c
  opcodes/loongarch-opc.c