### PR TITLE
Remove ase_test in structure LARCH_opts.

### DIFF
--- a/bfd/elfxx-loongarch.c
+++ b/bfd/elfxx-loongarch.c
@@ -104,7 +104,7 @@ struct elf_reloc_map
   enum elf_loongarch_reloc_type elf_val;
 };
 
-static const struct elf_reloc_map loong_reloc_map[] =
+static const struct elf_reloc_map larch_reloc_map[] =
 {
   { BFD_RELOC_NONE, R_LARCH_NONE },
   { BFD_RELOC_32, R_LARCH_32 },
@@ -175,9 +175,9 @@ loongarch_reloc_type_lookup (bfd *abfd ATTRIBUTE_UNUSED,
                              bfd_reloc_code_real_type code)
 {
   unsigned int i;
-  for (i = 0; i < ARRAY_SIZE (loong_reloc_map); i++)
-    if (loong_reloc_map[i].bfd_val == code)
-      return loongarch_elf_rtype_to_howto ((int) loong_reloc_map[i].elf_val);
+  for (i = 0; i < ARRAY_SIZE (larch_reloc_map); i++)
+    if (larch_reloc_map[i].bfd_val == code)
+      return loongarch_elf_rtype_to_howto ((int) larch_reloc_map[i].elf_val);
 
   return NULL;
 }

--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -173,7 +173,6 @@ loongarch_after_parse_args ()
 {
   size_t i;
 
-  LARCH_opts.ase_test = 1;
   LARCH_opts.ase_fix = 1;
   LARCH_opts.ase_float = 1;
   LARCH_opts.ase_128vec = 1;
@@ -249,27 +248,24 @@ loongarch_target_format ()
 void
 md_begin ()
 {
-  if (LARCH_opts.ase_test)
-    {
-      const struct loongarch_opcode *it;
-      struct loongarch_ase *ase;
-      for (ase = loongarch_ASEs; ase->enabled; ase++)
-        for (it = ase->opcodes; it->name; it++)
-          {
-            if (loongarch_check_format (it->format) != 0)
-              as_fatal (_ ("insn name: %s\tformat: %s\tsyntax error"),
-                        it->name, it->format);
-            if (it->mask == 0 && it->macro == 0)
-              as_fatal (_ ("insn name: %s\nformat: %s\nwe want macro but "
-                           "macro is NULL"),
-                        it->name, it->format);
-            if (it->macro &&
-                loongarch_check_macro (it->format, it->macro) != 0)
-              as_fatal (
-                _ ("insn name: %s\nformat: %s\nmacro: %s\tsyntax error"),
-                it->name, it->format, it->macro);
-          }
-    }
+  const struct loongarch_opcode *it;
+  struct loongarch_ase *ase;
+  for (ase = loongarch_ASEs; ase->enabled; ase++)
+    for (it = ase->opcodes; it->name; it++)
+      {
+        if (loongarch_check_format (it->format) != 0)
+          as_fatal (_ ("insn name: %s\tformat: %s\tsyntax error"),
+                    it->name, it->format);
+        if (it->mask == 0 && it->macro == 0)
+          as_fatal (_ ("insn name: %s\nformat: %s\nwe want macro but "
+                       "macro is NULL"),
+                    it->name, it->format);
+        if (it->macro &&
+            loongarch_check_macro (it->format, it->macro) != 0)
+          as_fatal (
+            _ ("insn name: %s\nformat: %s\nmacro: %s\tsyntax error"),
+            it->name, it->format, it->macro);
+      }
 
   /* FIXME: expressionS use 'offsetT' as constant, we want this is 64-bit type */
   assert (8 <= sizeof (offsetT));

--- a/include/elf/loongarch.h
+++ b/include/elf/loongarch.h
@@ -17,8 +17,8 @@
    along with this program; see the file COPYING3. If not,
    see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _ELF_LOONG_H
-#define _ELF_LOONG_H
+#ifndef _ELF_LOONGARCH_H
+#define _ELF_LOONGARCH_H
 
 #include "elf/reloc-macros.h"
 #include "libiberty.h"
@@ -98,4 +98,4 @@ END_RELOC_NUMBERS (R_LARCH_count)
 #define EF_LARCH_ABI_LP64 0x0003
 #define EF_LARCH_ABI_LP32 0x0001
 
-#endif /* _ELF_LOONG_H */
+#endif /* _ELF_LOONGARCH_H */

--- a/include/opcode/loongarch.h
+++ b/include/opcode/loongarch.h
@@ -190,7 +190,6 @@ Maybe need
 
   extern struct loongarch_ASEs_option
   {
-    int ase_test;
     int ase_fix;
     int ase_float;
     int ase_128vec;

--- a/ld/emultempl/loongarchelf.em
+++ b/ld/emultempl/loongarchelf.em
@@ -25,7 +25,7 @@ fragment <<EOF
 #include "elf/loongarch.h"
 
 static void
-loong_elf_before_allocation (void)
+larch_elf_before_allocation (void)
 {
   gld${EMULATION_NAME}_before_allocation ();
 
@@ -69,7 +69,7 @@ gld${EMULATION_NAME}_after_allocation (void)
    After the output has been created, but before inputs are read.  */
 
 static void
-loong_create_output_section_statements (void)
+larch_create_output_section_statements (void)
 {
   /* See PR 22920 for an example of why this is necessary.  */
   if (strstr (bfd_get_target (link_info.output_bfd), "loong") == NULL)
@@ -86,6 +86,6 @@ loong_create_output_section_statements (void)
 
 EOF
 
-LDEMUL_BEFORE_ALLOCATION=loong_elf_before_allocation
+LDEMUL_BEFORE_ALLOCATION=larch_elf_before_allocation
 LDEMUL_AFTER_ALLOCATION=gld${EMULATION_NAME}_after_allocation
-LDEMUL_CREATE_OUTPUT_SECTION_STATEMENTS=loong_create_output_section_statements
+LDEMUL_CREATE_OUTPUT_SECTION_STATEMENTS=larch_create_output_section_statements

--- a/opcodes/loongarch-dis.c
+++ b/opcodes/loongarch-dis.c
@@ -68,7 +68,6 @@ static const char *const *loongarch_x_disname = NULL;
 static void
 set_default_loongarch_dis_options (void)
 {
-  LARCH_opts.ase_test = 1;
   LARCH_opts.ase_fix = 1;
   LARCH_opts.ase_float = 1;
   LARCH_opts.ase_128vec = 1;

--- a/opcodes/loongarch-opc.c
+++ b/opcodes/loongarch-opc.c
@@ -23,7 +23,6 @@
 
 struct loongarch_ASEs_option LARCH_opts =
 {
-  .ase_test = 0,
   .ase_fix = 0,
   .ase_float = 0,
   .ase_128vec = 0,


### PR DESCRIPTION
            Remove ase_test in structure LARCH_opts.
    
    gas/config/tc-loongarch.c:
    173:remove "LARCH_opts.ase_test = 1;".
    249:remove "if" statement "if (LARCH_opts.ase_test) {...}".
    
    include/opcode/loongarch.h:
    190:remove "int ase_test;".
    
    opcodes/loongarch-dis.c:
    68:remove "LARCH_opts.ase_test = 1;".
    
    opcodes/loongarch-opc.c:
    23:remove ".ase_test = 0".