### PR TITLE
	Remove ase_test in structure LARCH_opts.

### DIFF
--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -176,7 +176,6 @@ loongarch_after_parse_args ()
 {
   size_t i;
 
-  LARCH_opts.ase_test = 1;
   LARCH_opts.ase_fix = 1;
   LARCH_opts.ase_float = 1;
   LARCH_opts.ase_128vec = 1;
@@ -252,27 +251,24 @@ loongarch_target_format ()
 void
 md_begin ()
 {
-  if (LARCH_opts.ase_test)
-    {
-      const struct loongarch_opcode *it;
-      struct loongarch_ase *ase;
-      for (ase = loongarch_ASEs; ase->enabled; ase++)
-	for (it = ase->opcodes; it->name; it++)
-	  {
-	    if (loongarch_check_format (it->format) != 0)
-	      as_fatal (_ ("insn name: %s\tformat: %s\tsyntax error"),
-			it->name, it->format);
-	    if (it->mask == 0 && it->macro == 0)
-	      as_fatal (_ ("insn name: %s\nformat: %s\nwe want macro but "
-			   "macro is NULL"),
-			it->name, it->format);
-	    if (it->macro
-	 && loongarch_check_macro (it->format, it->macro) != 0)
-	      as_fatal (
-		_ ("insn name: %s\nformat: %s\nmacro: %s\tsyntax error"),
-		it->name, it->format, it->macro);
-	  }
-    }
+  const struct loongarch_opcode *it;
+  struct loongarch_ase *ase;
+  for (ase = loongarch_ASEs; ase->enabled; ase++)
+    for (it = ase->opcodes; it->name; it++)
+      {
+        if (loongarch_check_format (it->format) != 0)
+          as_fatal (_ ("insn name: %s\tformat: %s\tsyntax error"),
+    		it->name, it->format);
+        if (it->mask == 0 && it->macro == 0)
+          as_fatal (_ ("insn name: %s\nformat: %s\nwe want macro but "
+    		   "macro is NULL"),
+    		it->name, it->format);
+        if (it->macro
+     && loongarch_check_macro (it->format, it->macro) != 0)
+          as_fatal (
+    	_ ("insn name: %s\nformat: %s\nmacro: %s\tsyntax error"),
+    	it->name, it->format, it->macro);
+      }
 
   /* FIXME: expressionS use 'offsetT' as constant,
    * we want this is 64-bit type.  */

--- a/include/opcode/loongarch.h
+++ b/include/opcode/loongarch.h
@@ -194,7 +194,6 @@ Maybe need
 
   extern struct loongarch_ASEs_option
   {
-    int ase_test;
     int ase_fix;
     int ase_float;
     int ase_128vec;

--- a/opcodes/loongarch-dis.c
+++ b/opcodes/loongarch-dis.c
@@ -69,7 +69,6 @@ static const char *const *loongarch_x_disname = NULL;
 static void
 set_default_loongarch_dis_options (void)
 {
-  LARCH_opts.ase_test = 1;
   LARCH_opts.ase_fix = 1;
   LARCH_opts.ase_float = 1;
   LARCH_opts.ase_128vec = 1;

--- a/opcodes/loongarch-opc.c
+++ b/opcodes/loongarch-opc.c
@@ -23,7 +23,6 @@
 
 struct loongarch_ASEs_option LARCH_opts =
 {
-  .ase_test = 0,
   .ase_fix = 0,
   .ase_float = 0,
   .ase_128vec = 0,


### PR DESCRIPTION
gas/config/tc-loongarch.c:
176:remove "LARCH_opts.ase_test = 1;".
252:remove "if" statement "if (LARCH_opts.ase_test) {...}".

include/opcode/loongarch.h:
194:remove "int ase_test;".

opcodes/loongarch-dis.c:
69:remove "LARCH_opts.ase_test = 1;".

opcodes/loongarch-opc.c:
23:remove ".ase_test = 0".