### PR TITLE
gdb: Do not define here, use the define in glibc

### DIFF
--- a/gdb/loongarch-linux-tdep.h
+++ b/gdb/loongarch-linux-tdep.h
@@ -22,9 +22,7 @@
 #define LOONGARCH_LINUX_TDEP_H
 
 #include <regset.h>
-
-#define ELF_NGREG   45
-#define ELF_NFPREG  34
+#include <sys/procfs.h>
 
 typedef uint64_t loongarch_elf_gregset_t[ELF_NGREG];
 extern const struct regset loongarch_elf_gregset;


### PR DESCRIPTION
ELF_NGREG and ELF_NFPREG already defined in <sys/procfs.h>