### PR TITLE
fix build warning.

### DIFF
--- a/gas/config/loongarch-lex.l
+++ b/gas/config/loongarch-lex.l
@@ -20,6 +20,10 @@
 %{
 #include "as.h"
 #include "loongarch-parse.h"
+
+/* Flex generates static functions "input" & "unput" which are not used.  */
+#define YY_NO_INPUT
+#define YY_NO_UNPUT
 %}
 
 D	[0-9]


### PR DESCRIPTION
```
config/loongarch-lex.c:1232:16: 警告：‘input’ defined but not used [-Wunused-function]
 #else
                ^
config/loongarch-lex.c:1189:17: 警告：‘yyunput’ defined but not used [-Wunused-function]

                 ^
```