### PR TITLE
ld: loongarch: remove "64/lib64" from LIBPATH_SUFFIX

### DIFF
--- a/ld/emulparams/elf64loongarch.sh
+++ b/ld/emulparams/elf64loongarch.sh
@@ -5,7 +5,7 @@ case "$target" in
   loongarch64*-linux*)
     case "$EMULATION_NAME" in
       *64*)
-	LIBPATH_SUFFIX="64/lib64 64";;
+	LIBPATH_SUFFIX="64";;
     esac
     ;;
 esac


### PR DESCRIPTION
It is producing some SEARCH_DIR with paths like

/usr/loongarch64-unknown-linux-gnu/lib6464/lib64

This just does not make any sense.  The only architecture supported by
upstream using this kind of suffix is "rv32". To me they just introduced
this thing for "backward compatibility", which we don't need to care at
all.