### PR TITLE
bfd: loongarch: fix reloc size for MARK_PCREL and MARK_LA

### DIFF
--- a/bfd/elfxx-loongarch.c
+++ b/bfd/elfxx-loongarch.c
@@ -37,6 +37,9 @@ static reloc_howto_type howto_table[] =
 #define LOONGARCH_HOWTO(r_name)						 \
   HOWTO (R_LARCH_##r_name, 0, 2, 32, false, 0, complain_overflow_signed, \
 	 bfd_elf_generic_reloc, "R_LARCH_" #r_name, false, 0, 0xffffffff, false)
+#define LOONGARCH_MARK(r_name)						 \
+  HOWTO (R_LARCH_##r_name, 0, 3, 0, false, 0, complain_overflow_dont, \
+	 bfd_elf_generic_reloc, "R_LARCH_" #r_name, false, 0, 0, false)
   LOONGARCH_HOWTO (NONE),
 
   /* 32 bit relocation.  */
@@ -210,8 +213,8 @@ static reloc_howto_type howto_table[] =
 	 0xffffffff,			/* dst_mask */
 	 false),			/* pcrel_offset */
 
-  LOONGARCH_HOWTO (MARK_LA),
-  LOONGARCH_HOWTO (MARK_PCREL),
+  LOONGARCH_MARK (MARK_LA),
+  LOONGARCH_MARK (MARK_PCREL),
   HOWTO (R_LARCH_SOP_PUSH_PCREL,	      	/* type.  */
 	 2,				   	/* rightshift.  */
 	 2,				   	/* size.  */


### PR DESCRIPTION
They are just marks, they don't write any relocated value into the code.
So the size field should be 3 (translated to zero by
bfd_get_reloc_size) and bitsize should be 0.

Fix a "fixup not contained within frag" internal error building Huacai's
kernel with CONFIG_DRM_AMDGPU=m.

先凑合能用吧，剩下一堆栈操作的 size 和 bitsize 根本不知道咋办。
像目前这样栈操作不要跨越指令边界应该还行，如果真的跨指令当
图灵完整的自动机用肯定能搞出 114514 个 bug。

直接搞一组固定移位/掩码的重定位不香吗……