### PR TITLE
gas/gdb: Delete extern from *.c, include *.h instead.

### DIFF
--- a/gas/config/loongarch-lex.h
+++ b/gas/config/loongarch-lex.h
@@ -1,0 +1,34 @@
+/*
+   Copyright (C) 2021 Free Software Foundation, Inc.
+
+   This file is part of GAS, the GNU Assembler.
+
+   GAS is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
+
+   GAS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; see the file COPYING3.  If not,
+   see <http://www.gnu.org/licenses/>.  */
+
+
+struct yy_buffer_state;
+
+
+struct yy_buffer_state *yy_scan_string (const char *);
+void yy_delete_buffer (struct yy_buffer_state *b);
+void get_internal_label (expressionS *label_expr,
+			unsigned long label,
+		    	int augend);
+int
+loongarch_parse_expr (const char *expr,
+		      struct reloc_info *reloc_stack_top,
+		      size_t max_reloc_num,
+		      size_t *reloc_num,
+		      offsetT *imm);

--- a/gas/config/loongarch-parse.y
+++ b/gas/config/loongarch-parse.y
@@ -18,16 +18,12 @@
    see <http://www.gnu.org/licenses/>.  */
 %{
 #include "as.h"
+#include "loongarch-lex.h"
 #include "loongarch-parse.h"
 static void yyerror (const char *s ATTRIBUTE_UNUSED)
 {
 };
-extern int yylex (void);
-extern void yy_scan_string (const char *);
-extern void
-get_internal_label (expressionS *label_expr,
-		    unsigned long label,
-		    int augend);
+int yylex (void);
 
 
 static struct reloc_info *top, *end;
@@ -50,20 +46,15 @@ loongarch_parse_expr (const char *expr,
 		      struct reloc_info *reloc_stack_top,
 		      size_t max_reloc_num,
 		      size_t *reloc_num,
-		      offsetT *imm);
-
-int
-loongarch_parse_expr (const char *expr,
-		      struct reloc_info *reloc_stack_top,
-		      size_t max_reloc_num,
-		      size_t *reloc_num,
 		      offsetT *imm)
 {
   int ret;
+  struct yy_buffer_state *buffstate;
   top = reloc_stack_top;
   end = top + max_reloc_num;
-  yy_scan_string (expr);
+  buffstate = yy_scan_string (expr);
   ret = yyparse ();
+
   if (ret == 0)
     {
       if (is_const (top - 1))
@@ -72,6 +63,8 @@ loongarch_parse_expr (const char *expr,
 	*imm = 0;
       *reloc_num = top - reloc_stack_top;
     }
+  yy_delete_buffer (buffstate);
+
   return ret;
 }
 

--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -21,6 +21,7 @@
 
 #include "as.h"
 #include "dw2gencfi.h"
+#include "loongarch-lex.h"
 #include "elf/loongarch.h"
 #include "opcode/loongarch.h"
 #include "obj-elf.h"
@@ -390,11 +391,6 @@ setup_internal_label_here (unsigned long label)
   colon (loongarch_internal_label_name (label, 0));
 }
 
-/* No static. used by 'loongarch-parse.y'.   */
-extern void
-get_internal_label (expressionS *label_expr, unsigned long label,
-		    int augend /* 0 for previous, 1 for next.  */);
-
 void
 get_internal_label (expressionS *label_expr, unsigned long label,
 		    int augend /* 0 for previous, 1 for next.  */)
@@ -407,11 +403,6 @@ get_internal_label (expressionS *label_expr, unsigned long label,
     symbol_find_or_make (loongarch_internal_label_name (label, augend));
   label_expr->X_add_number = 0;
 }
-
-extern int loongarch_parse_expr (const char *expr,
-				 struct reloc_info *reloc_stack_top,
-				 size_t max_reloc_num, size_t *reloc_num,
-				 offsetT *imm_if_no_reloc);
 
 static int32_t
 loongarch_args_parser_can_match_arg_helper (char esc_ch1, char esc_ch2,

--- a/gdb/loongarch-linux-nat.c
+++ b/gdb/loongarch-linux-nat.c
@@ -87,10 +87,6 @@ private:
   void loongarch_store_regs (struct regcache *regcache, int regno);
 };
 
-/* Assume that we have PTRACE_{GET,SET}REGSET et al. support.  If we do not,
-   we'll clear this and use PTRACE_PEEKUSR instead.  */
-extern enum tribool have_ptrace_getregset;
-
 static void
 ensure_ptrace_getregset ()
 {


### PR DESCRIPTION
  gas/config/loongarch-lex.h
  gas/config/loongarch-parse.y
  gas/config/tc-loongarch.c
  gdb/loongarch-linux-nat.c