### PR TITLE
LoongArch targets cannot convert format in the linker using the --oformat command line switch

### DIFF
--- a/ld/testsuite/ld-srec/srec.exp
+++ b/ld/testsuite/ld-srec/srec.exp
@@ -291,6 +291,12 @@ proc run_srec_test { test objs } {
 	setup_xfail "riscv*-*-*"
     }
 
+    # loongArch targets cannot convert format in the linker
+    # using the --oformat command line switch
+    if [istarget loongarch*-*-*] {
+	setup_xfail "loongarch*-*-*"
+    }
+
     # V850 targets need libgcc.a
     if [istarget v850*-*-elf] {
 	set objs "$objs -L ../gcc -lgcc"

--- a/ld/testsuite/ld-unique/pr21529.d
+++ b/ld/testsuite/ld-unique/pr21529.d
@@ -1,6 +1,6 @@
 #ld: --oformat binary -T pr21529.ld -e main
 #objdump: -s -b binary
-#xfail: aarch64*-*-* arm*-*-* avr-*-* ia64-*-* m68hc1*-*-* nds32*-*-* riscv*-*-* score-*-* v850-*-*
+#xfail: aarch64*-*-* arm*-*-* avr-*-* ia64-*-* m68hc1*-*-* nds32*-*-* riscv*-*-* score-*-* v850-*-* loongarch*-*-*
 # Skip targets which can't change output format to binary.
 
 #pass


### PR DESCRIPTION
LoongArch targets cannot convert format in the linker using the --oformat command line switch, so skip targets:


        1. ld/testsuite/ld-srec/srec.exp
        2. ld/testsuite/ld-unique/pr21529.d