### PR TITLE
gas/ld: Add reloc mask.

### DIFF
--- a/bfd/elfnn-loongarch.c
+++ b/bfd/elfnn-loongarch.c
@@ -1468,7 +1468,8 @@ loongarch_reloc_rewrite_imm_insn (const Elf_Internal_Rela *rel,
   if (!loongarch_adjust_reloc_bitsfield(howto, &reloc_val))
       return bfd_reloc_overflow;
 
-  insn |= (uint32_t)reloc_val;
+  insn = (insn & (uint32_t)howto->src_mask)
+	  | ((insn & (~(uint32_t)howto->dst_mask)) | reloc_val);
 
   bfd_put (bits, input_bfd, insn, contents + rel->r_offset);
   return bfd_reloc_ok;

--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -1072,7 +1072,9 @@ static void fix_reloc_insn (fixS *fixP, bfd_vma reloc_val, char *buf)
   if (!loongarch_adjust_reloc_bitsfield(howto, &reloc_val))
     as_warn_where (fixP->fx_file, fixP->fx_line, "Reloc overflow");
 
-  insn |= (insn_t)reloc_val;
+  insn = (insn & (insn_t)howto->src_mask)
+    | ((insn & (~(insn_t)howto->dst_mask)) | reloc_val);
+
   bfd_putl32 (insn, buf);
 }
 


### PR DESCRIPTION
  bfd/elfnn-loongarch.c
  gas/config/tc-loongarch.c

	=== gas Summary ===
 of expected passes		256
 of expected failures		2
 of unsupported tests		3

       	=== binutils Summary ===
 of expected passes		233
 of unsupported tests		6

       	=== ld Summary ===
 of expected passes		1405
 of unexpected failures	11
 of unexpected successes	1
 of expected failures		10
 of untested testcases		1
 of unsupported tests		140