### PR TITLE
Fix wrong line number in .debug_line

### DIFF
--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -858,6 +858,9 @@ append_fixp_and_insn (struct loongarch_cl_insn *ip)
   bfd_reloc_code_real_type reloc_type;
   struct reloc_info *reloc_info = ip->reloc_info;
   size_t i;
+
+  dwarf2_emit_insn (0);
+
   for (i = 0; i < ip->reloc_num; i++)
     {
       reloc_type = reloc_info[i].type;
@@ -874,7 +877,6 @@ append_fixp_and_insn (struct loongarch_cl_insn *ip)
     as_fatal (_ ("Internal error: not support relax now"));
   else
     append_fixed_insn (ip);
-  dwarf2_emit_insn (0);
 }
 
 /* Ask helper for returning a malloced c_str or NULL.  */


### PR DESCRIPTION
The dwarf2_emit_insn() can create debuginfo of line. But it is called
too late in append_fixp_and_insn. It causes extra offs when debuginfo
of line sets address.

$ cat a.c -n
     1	int a()
     2	{
     3		bar();
     4	}
$ gcc -c a.c -o a.o -w -g
$ objdump -d a.o

a.o：     文件格式 elf64-loongarch


Disassembly of section .text:

0000000000000000 <a>:
   0:	02ffc063 	addi.d      	$sp, $sp, -16(0xff0)

0000000000000004 <L0^A>:
   4:	29c02061 	st.d        	$ra, $sp, 8(0x8)
   8:	27000076 	stptr.d     	$fp, $sp, 0
   c:	02c04076 	addi.d      	$fp, $sp, 16(0x10)
  10:	54000000 	bl          	0	# 10 <L0^A+0xc>
  14:	03400000 	andi        	$zero, $zero, 0x0
  18:	00150184 	move        	$a0, $t0
  1c:	28c02061 	ld.d        	$ra, $sp, 8(0x8)
  20:	26000076 	ldptr.d     	$fp, $sp, 0
  24:	02c04063 	addi.d      	$sp, $sp, 16(0x10)
  28:	4c000020 	jirl        	$zero, $ra, 0

$ addr2line 0x10 -e a.o -C -s
a.c:2

$ readelf -r a.o
重定位节 '.rela.debug_line' at offset 0x650 contains 1 entry:
    偏移量             信息             类型               符号值          符号名称 + 加数
0000000000000029  0000000700000002 R_LARCH_64             0000000000000004 L0^A + 0