### PR TITLE
Fix gas bug:

### DIFF
--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -967,7 +967,8 @@ assember_macro_helper (const char *const args[], void *context_ptr)
 	}
       while (0);
 
-      ret = loongarch_expand_macro (insns_buf, arg_strs, NULL, NULL);
+      ret = loongarch_expand_macro (insns_buf, arg_strs, NULL, NULL,
+                                    sizeof (args_buf));
     }
   return ret;
 }
@@ -979,6 +980,7 @@ static void
 loongarch_assemble_INSNs (char *str)
 {
   char *rest;
+  size_t len_str = strlen(str);
 
   for (rest = str; *rest != ';' && *rest != '\0'; rest++);
   if (*rest == ';')
@@ -1024,7 +1026,7 @@ loongarch_assemble_INSNs (char *str)
 	  char *c_str = loongarch_expand_macro (the_one.insn->macro,
 						the_one.arg_strs,
 						assember_macro_helper,
-						&the_one);
+						&the_one, len_str);
 	  loongarch_assemble_INSNs (c_str);
 	  free (c_str);
 	}

--- a/include/opcode/loongarch.h
+++ b/include/opcode/loongarch.h
@@ -163,11 +163,11 @@ dec2 : [1-9][0-9]?
     const char *format, const char *macro, const char *const arg_strs[],
     const char *(*map) (char esc1, char esc2, const char *arg),
     char *(*helper) (const char *const arg_strs[], void *context),
-    void *context);
+    void *context, size_t len_str);
   extern char *loongarch_expand_macro (
     const char *macro, const char *const arg_strs[],
     char *(*helper) (const char *const arg_strs[], void *context),
-    void *context);
+    void *context, size_t len_str);
   extern size_t loongarch_bits_imm_needed (int64_t imm, int si);
 
   extern void loongarch_eliminate_adjacent_repeat_char (char *dest, char c);

--- a/opcodes/loongarch-coder.c
+++ b/opcodes/loongarch-coder.c
@@ -377,13 +377,18 @@ char *
 loongarch_expand_macro_with_format_map (
   const char *format, const char *macro, const char *const arg_strs[],
   const char *(*map) (char esc1, char esc2, const char *arg),
-  char *(*helper) (const char *const arg_strs[], void *context), void *context)
+  char *(*helper) (const char *const arg_strs[], void *context), void *context,
+  size_t len_str)
 {
   char esc1s[MAX_ARG_NUM_PLUS_2 - 1], esc2s[MAX_ARG_NUM_PLUS_2 - 1];
   const char *bit_fields[MAX_ARG_NUM_PLUS_2 - 1];
   const char *src;
   char *dest;
-  char buffer[8192];
+  /*The expanded macro character length does not exceed 1000, and number of
+   * label is 6 at most in the expanded macro. The len_str is the length of
+   * str.
+   */
+  char *buffer =(char *) malloc(1000 +  6 * len_str);
 
   if (format)
     loongarch_parse_format (format, esc1s, esc2s, bit_fields);
@@ -421,17 +426,17 @@ loongarch_expand_macro_with_format_map (
       *dest++ = *src++;
 
   *dest = '\0';
-  return strdup (buffer);
+  return buffer;
 }
 
 char *
 loongarch_expand_macro (const char *macro, const char *const arg_strs[],
 			char *(*helper) (const char *const arg_strs[],
 					 void *context),
-			void *context)
+			void *context, size_t len_str)
 {
   return loongarch_expand_macro_with_format_map (NULL, macro, arg_strs, I,
-						 helper, context);
+						 helper, context, len_str);
 }
 
 size_t


### PR DESCRIPTION
    Segment error in compilation due to too
    long symbol name.

    change "char buffer[8192];" into "char *buffer =
    (char *) malloc(1000 +  6 * len_str);"in function
    loongarch_expand_macro_with_format_map.

    gas/config/tc-loongarch.c
    include/opcode/loongarch.h
    opcodes/loongarch-coder.c