### PR TITLE
Fix wrong line number in .debug_line

### DIFF
--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -869,6 +869,9 @@ append_fixp_and_insn (struct loongarch_cl_insn *ip)
   bfd_reloc_code_real_type reloc_type;
   struct reloc_info *reloc_info = ip->reloc_info;
   size_t i;
+
+  dwarf2_emit_insn (0);
+
   for (i = 0; i < ip->reloc_num; i++)
     {
       reloc_type = reloc_info[i].type;
@@ -885,7 +888,6 @@ append_fixp_and_insn (struct loongarch_cl_insn *ip)
     as_fatal (_ ("Internal error: not support relax now"));
   else
     append_fixed_insn (ip);
-  dwarf2_emit_insn (0);
 }
 
 /* Ask helper for returning a malloced c_str or NULL.  */


### PR DESCRIPTION
The dwarf2_emit_insn() can create debuginfo of line. But it is called
too late in append_fixp_and_insn. It causes extra offs when debuginfo
of line sets address.