### PR TITLE
LoongArch: Insn pcalau12i support lable.

### DIFF
--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -1034,8 +1034,10 @@ loongarch_assemble_INSNs (char *str)
       append_fixp_and_insn (&the_one);
       if (the_one.insn_length == 0 && the_one.insn->macro)
 	{
-	  if (!strncmp (the_one.insn->name, "la.", 3)
+	  if ((!strncmp (the_one.insn->name, "la.", 3)
 	      && strstr (the_one.insn->macro, "(" FAKE_LABEL_NAME ")"))
+	      || (!strcmp(the_one.insn->name, "pcalau12i")
+		  && the_one.insn->macro))
 	    {
 	      fake_ep->X_add_symbol = make_internal_label ();
 	    }

--- a/gas/testsuite/gas/loongarch/macro_op.d
+++ b/gas/testsuite/gas/loongarch/macro_op.d
@@ -166,3 +166,5 @@ Disassembly of section .text:
 [ 	]+150:[ 	]+030000a5[ 	]+[ 	]+lu52i.d[ 	]+\$a1, \$a1, 0
 [ 	]+[ 	]+[ 	]+150: R_LARCH_PCREL_H_HI12[ 	]+.text\+0x144
 [ 	]+154:[ 	]+00109484[ 	]+[ 	]+add.d[ 	]+\$a0, \$a0, \$a1
+[ 	]+158:[ 	]+1a000004[ 	]+[ 	]+pcalau12i[ 	]+\$a0, 0
+[ 	]+[ 	]+[ 	]+158: R_LARCH_PCREL32_HI20[ 	]+L1

--- a/gas/testsuite/gas/loongarch/macro_op.s
+++ b/gas/testsuite/gas/loongarch/macro_op.s
@@ -1,4 +1,3 @@
-.L1:
 li.w  $r4,0
 li.w  $r4,0xffffffff
 li.d  $r4,0
@@ -27,3 +26,4 @@ la.tls.ld  $r4,L1
 la.tls.ld  $r4,$r5,L1
 la.tls.gd  $r4,L1
 la.tls.gd  $r4,$r5,L1
+pcalau12i  $r4,L1

--- a/opcodes/loongarch-opc.c
+++ b/opcodes/loongarch-opc.c
@@ -202,20 +202,21 @@ static struct loongarch_opcode loongarch_macro_opcodes[] =
   { 0, 0, "li.w", "r,sc", "%f",	0, 0, 0 },
   { 0, 0, "li.d", "r,sc", "%f",	0, 0, 0 },
 
-  { 0, 0, "la",	  "r,l", "la.global %1,%2",  0, 0, 0 },
+  { 0, 0, "pcalau12i",	"r,l",	  "pcalau12i %1,%%pcrel32_hi20(%2);", 0, 0, 0 },
 
+  { 0, 0, "la",		"r,l",	  "la.global %1,%2",	0,			0, 0 },
   { 0, 0, "la.global",	"r,l",	  "la.pcrel %1,%2",	&LARCH_opts.ase_gpcr,	0, 0 },
   { 0, 0, "la.global",	"r,r,l",  "la.pcrel %1,%2,%3",	&LARCH_opts.ase_gpcr,	0, 0 },
   { 0, 0, "la.global",	"r,l",	  "la.abs %1,%2",	&LARCH_opts.ase_gabs,	0, 0 },
   { 0, 0, "la.global",	"r,r,l",  "la.abs %1,%3",	&LARCH_opts.ase_gabs,	0, 0 },
-  { 0, 0, "la.global",	"r,l",	  "la.got %1,%2",	&LARCH_opts.ase_ilp32,	0, 0 },
+  { 0, 0, "la.global",	"r,l",	  "la.got %1,%2",	0,			0, 0 },
   { 0, 0, "la.global",	"r,r,l",  "la.got %1,%2,%3",	&LARCH_opts.ase_lp64,	0, 0 },
 
   { 0, 0, "la.local",	"r,l",	  "la.abs %1,%2",	&LARCH_opts.ase_labs,	0, 0 },
   { 0, 0, "la.local",	"r,r,l",  "la.abs %1,%3",	&LARCH_opts.ase_labs,	0, 0 },
-  { 0, 0, "la.local",	"r,l",	  "la.pcrel %1,%2",	&LARCH_opts.ase_ilp32,	0, 0 },
+  { 0, 0, "la.local",	"r,l",	  "la.pcrel %1,%2",	0,			0, 0 },
   { 0, 0, "la.local",	"r,r,l",  "la.pcrel %1,%2,%3",	&LARCH_opts.ase_lp64,	0, 0 },
-  { 0, 0, "la.tls.ld",	"r,l",	  "la.tls.gd %1,%2",	&LARCH_opts.ase_ilp32,	0, 0 },
+  { 0, 0, "la.tls.ld",	"r,l",	  "la.tls.gd %1,%2",	0,			0, 0 },
   { 0, 0, "la.tls.ld",	"r,r,l",  "la.tls.gd %1,%2,%3", &LARCH_opts.ase_lp64,	0, 0 },
 
   { 0, 0, "la.abs",	"r,l",	  INSN_LA_ABS_32,	    0 },


### PR DESCRIPTION
=== 32 gas Summary ===
# of expected passes		264
# of unsupported tests		7
=== 32 binutils Summary ===
# of expected passes		212
# of untested testcases		15
# of unsupported tests		10
=== 32 ld Summary ===
# of expected passes		676
# of expected failures		4
# of untested testcases		26
# of unsupported tests		176

=== 64 gas Summary ===
# of expected passes		265
# of unsupported tests		7
=== 64 binutils Summary ===
# of expected passes		236
# of unsupported tests		6
=== 64 ld Summary ===
# of expected passes		1441
# of unexpected failures	2
# of expected failures		10
# of untested testcases		1
# of unsupported tests		154
