### PR TITLE
Add support about gas cfi derictives for loongarch register name

### DIFF
--- a/gas/config/tc-loongarch.c
+++ b/gas/config/tc-loongarch.c
@@ -1255,10 +1255,38 @@ loongarch_dwarf2_addr_size (void)
   return LARCH_opts.ase_lp64 ? 8 : 4;
 }
 
-void
-tc_loongarch_parse_to_dw2regnum (expressionS *exp)
+int
+tc_loongarch_regname_to_dw2regnum (char *regname)
 {
-  expression_and_evaluate (exp);
+  if (*regname != '$')
+    {
+      as_bad (_("unknown register `%s'"), regname);
+      return -1;
+    }
+
+  void *t = NULL;
+  // mark_f is used to output float regno.
+  int mark_f = 0;
+  if (*(regname + 1) == 'f' && *(regname + 2) != 'p')
+    {
+      mark_f = 1;
+      t = str_hash_find (f_htab, regname);
+    }
+  else
+    t = str_hash_find (r_htab, regname);
+
+  if (t != NULL)
+    {
+      if (mark_f == 1)
+        return (offsetT) t - 1 + 32;
+      else
+        return (offsetT) t - 1;
+    }
+  else
+    {
+      as_bad (_("unknown register `%s'"), regname);
+      return -1;
+    }
 }
 
 void

--- a/gas/config/tc-loongarch.h
+++ b/gas/config/tc-loongarch.h
@@ -68,8 +68,10 @@ extern int loongarch_dwarf2_addr_size (void);
   loongarch_cfi_frame_initial_instructions
 extern void loongarch_cfi_frame_initial_instructions (void);
 
-#define tc_parse_to_dw2regnum tc_loongarch_parse_to_dw2regnum
-extern void tc_loongarch_parse_to_dw2regnum (expressionS *);
+//#define tc_parse_to_dw2regnum tc_loongarch_parse_to_dw2regnum
+//extern void tc_loongarch_parse_to_dw2regnum (expressionS *);
+#define tc_regname_to_dw2regnum    tc_loongarch_regname_to_dw2regnum
+extern int tc_loongarch_regname_to_dw2regnum (char *regname);
 
 /* A enumerated values to specific how to deal with align in '.text'.
    Now we want to fill 'andi $r0,$r0,0x0'.

--- a/gas/testsuite/gas/cfi/cfi-loongarch-1.d
+++ b/gas/testsuite/gas/cfi/cfi-loongarch-1.d
@@ -1,0 +1,31 @@
+#readelf: -wf
+#name: CFI on LOONGARCH
+
+Contents of the .eh_frame section:
+
+
+00000000 0+0010 0+00 CIE
+  Version:               1
+  Augmentation:          "zR"
+  Code alignment factor: 1
+  Data alignment factor: -4
+  Return address column: 1
+  Augmentation data:     0c
+  DW_CFA_def_cfa_register: r3
+  DW_CFA_nop
+
+00000014 0+0028 0+0018 FDE cie=0+00 pc=0+00..0+0020
+  DW_CFA_advance_loc: 4 to 0+004
+  DW_CFA_offset: r11 at cfa\+0
+  DW_CFA_def_cfa_offset: 16
+  DW_CFA_advance_loc: 4 to 0+008
+  DW_CFA_offset: r22 at cfa-8
+  DW_CFA_advance_loc: 4 to 0+00c
+  DW_CFA_def_cfa: r22 ofs 0
+  DW_CFA_advance_loc: 12 to 0+0018
+  DW_CFA_restore: r22
+  DW_CFA_advance_loc: 4 to 0+001c
+  DW_CFA_def_cfa_register: r3
+  DW_CFA_nop
+  DW_CFA_nop
+

--- a/gas/testsuite/gas/cfi/cfi-loongarch-1.s
+++ b/gas/testsuite/gas/cfi/cfi-loongarch-1.s
@@ -1,0 +1,27 @@
+	.file	1 "a.c"
+	.text
+	.align	2
+	.globl	main
+	.type	main, @function
+main:
+.LFB0 = .
+	.cfi_startproc
+	addi.d	$r3,$r3,-16
+	.cfi_rel_offset $r11, 0
+	.cfi_def_cfa_offset 16
+	st.d	$r22,$r3,8
+	.cfi_offset 22, -8
+	addi.d	$r22,$r3,16
+	.cfi_def_cfa 22, 0
+	or	$r12,$r0,$r0
+	or	$r4,$r12,$r0
+	ld.d	$r22,$r3,8
+	.cfi_restore 22
+	addi.d	$r3,$r3,16
+	.cfi_def_cfa_register 3
+	jr	$r1
+	.cfi_endproc
+.LFE0:
+	.size	main, .-main
+	.section	.note.GNU-stack,"",@progbits
+	.ident	"GCC: (GNU) 8.3.0 20190222 (Loongson 8.3.0-23 vec)"

--- a/gas/testsuite/gas/cfi/cfi.exp
+++ b/gas/testsuite/gas/cfi/cfi.exp
@@ -109,6 +109,9 @@ if  { [istarget "i*86-*-*"] || [istarget "x86_64-*-*"] } then {
 	run_dump_test "cfi-sparc64-1"
     }
 
+} elseif { [istarget loongarch*-*-*] } then {
+	run_dump_test "cfi-loongarch-1"
+	return
 } else {
     return
 }


### PR DESCRIPTION
1. Add support about gas cfi derictives for loongarch  register name：
 
Add the function mainly:
                    tc_loongarch_regname_to_dw2regnum
    
            files has been changed:
                    gas/config/tc-loongarch.c
                    gas/config/tc-loongarch.h

2.  Add loongarch cfi testcase.
    
        gas/testsuite/gas/cfi/cfi-loongarch-1.d
        gas/testsuite/gas/cfi/cfi-loongarch-1.s
        gas/testsuite/gas/cfi/cfi.exp

