### PR TITLE
LoongArch: ld: Support 2G jmp.

### DIFF
--- a/bfd/elfnn-loongarch.c
+++ b/bfd/elfnn-loongarch.c
@@ -3075,8 +3075,20 @@ loongarch_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
 	  else
 	    relocation += rel->r_addend;
 
-	  relocation &= 0xfff;
+	    {
+	      relocation &= 0xfff;
+	      /* Signed extend.  */
+	      relocation = (relocation ^ 0x800) - 0x800;
 
+	      /* For 2G jump, generate pcalau12i, jirl.  */
+	      /* If use jirl, turns to R_LARCH_B16.  */
+	      uint32_t insn = bfd_get (32, input_bfd, contents + rel->r_offset);
+	      if ((insn & 0x4c000000) == 0x4c000000)
+		{
+		  rel->r_info = ELFNN_R_INFO (r_symndx, R_LARCH_B16);
+		  howto = loongarch_elf_rtype_to_howto (input_bfd, R_LARCH_B16);
+		}
+	    }
 	  break;
 
 	case R_LARCH_PCALA64_LO20:


### PR DESCRIPTION
  Usage:
    pcalau12i pc_hi20(func)
    jirl  pc_lo12(func)

  bfd/
    elfnn-loongarch.c