### PR TITLE
Revert "LoongArch: Add support -no-relax"

### DIFF
--- a/bfd/elfnn-loongarch.c
+++ b/bfd/elfnn-loongarch.c
@@ -2223,13 +2223,6 @@ loongarch_reloc_is_fatal (struct bfd_link_info *info,
   return fatal;
 }
 
-static bool enable_relax = true;
-
-void
-bfd_elfNN_loongarch_set_option_relax (bool relax)
-{
-  enable_relax = relax;
-}
 
 #define RELOCATE_CALC_PC32_HI20(relocation, pc) 	\
   ({							\
@@ -2273,9 +2266,6 @@ relax_record (bfd *input_bfd, bfd_vma sym, bfd_vma pc,
 	      Elf_Internal_Rela *rel, bfd_byte *contents,
 	      bool is_hi)
 {
-  if (!enable_relax)
-    return;
-
   relax_reloc **p;
   if (!relax_relocs)
     p = &relax_relocs;

--- a/bfd/elfxx-loongarch.h
+++ b/bfd/elfxx-loongarch.h
@@ -33,13 +33,8 @@ loongarch_reloc_name_lookup (bfd *abfd ATTRIBUTE_UNUSED, const char *r_name);
 extern bfd_reloc_code_real_type
 loongarch_larch_reloc_name_lookup (bfd *abfd ATTRIBUTE_UNUSED,
 				   const char *l_r_name);
-bool
-loongarch_adjust_reloc_bitsfield (reloc_howto_type *howto, bfd_vma *fix_val);
 
-void
-bfd_elf32_loongarch_set_option_relax (bool relax);
-void
-bfd_elf64_loongarch_set_option_relax (bool relax);
+bool loongarch_adjust_reloc_bitsfield (reloc_howto_type *howto, bfd_vma *fix_val);
 
 /* TRUE if this is a PLT reference to a local IFUNC.  */
 #define PLT_LOCAL_IFUNC_P(INFO, H) \

--- a/ld/emultempl/loongarchelf.em
+++ b/ld/emultempl/loongarchelf.em
@@ -23,7 +23,6 @@ fragment <<EOF
 #include "ldmain.h"
 #include "ldctor.h"
 #include "elf/loongarch.h"
-#include "elfxx-loongarch.h"
 
 static void
 larch_elf_before_allocation (void)
@@ -69,7 +68,6 @@ gld${EMULATION_NAME}_after_allocation (void)
 /* This is a convenient point to tell BFD about target specific flags.
    After the output has been created, but before inputs are read.  */
 
-static bool enable_relax = true;
 static void
 larch_create_output_section_statements (void)
 {
@@ -80,25 +78,9 @@ larch_create_output_section_statements (void)
 	       " whilst linking %s binaries\n"), "LoongArch");
       return;
     }
-  bfd_elf${ELFSIZE}_loongarch_set_option_relax (enable_relax);
 }
 
 EOF
-
-
-PARSE_AND_LIST_PROLOGUE='
-#define OPTION_NO_RELAX	301
-'
-
-PARSE_AND_LIST_LONGOPTS='
-  { "no-relax", required_argument, NULL, OPTION_NO_RELAX},
-'
-
-PARSE_AND_LIST_ARGS_CASES='
-case OPTION_NO_RELAX:
-enable_relax = false;
-break;
-'
 
 LDEMUL_BEFORE_ALLOCATION=larch_elf_before_allocation
 LDEMUL_AFTER_ALLOCATION=gld${EMULATION_NAME}_after_allocation


### PR DESCRIPTION
This reverts commit 412e6e47bcd1dca43059e1acf34ee78c30586b7e.
revert -no-relax option